### PR TITLE
Remove leading column from merged corrections file.

### DIFF
--- a/corrected_labels/all_conll_corrections_combined.csv
+++ b/corrected_labels/all_conll_corrections_combined.csv
@@ -1,1165 +1,1165 @@
 fold,doc_offset,corpus_span,corpus_ent_type,error_type,correct_span,correct_ent_type,agreeing_models,notes,Original entrants ensemble,custom models ensemble,cross validation ensemble,hand_labelled
-dev,2,"[122, 129): 'England'",LOC,Tag,"[122, 129): 'England'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-dev,2,"[1354, 1362): 'Scotland'",LOC,Tag,"[1354, 1362): 'Scotland'",ORG,,,FALSE,FALSE,FALSE,TRUE
-dev,2,"[235, 244): 'Australia'",LOC,Tag,"[235, 244): 'Australia'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-dev,2,"[525, 533): 'Scotland'",LOC,Tag,"[525, 533): 'Scotland'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-dev,2,"[61, 70): 'Australia'",LOC,Tag,"[61, 70): 'Australia'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-dev,2,"[760, 765): 'Leeds'",ORG,Tag,"[760, 765): 'Leeds'",LOC,,,FALSE,TRUE,TRUE,TRUE
-dev,6,"[47, 56): 'VOLGOGRAD'",LOC,Tag,"[47, 56): 'VOLGOGRAD'",ORG,16,,FALSE,TRUE,FALSE,FALSE
-dev,7,"[1004, 1022): 'Boxing Association'",ORG,Span,"[993, 1022): 'Panamanian Boxing Association'",ORG,,,FALSE,FALSE,TRUE,TRUE
-dev,11,"[1967, 1975): 'Republic'",LOC,Sentence,"[1961, 1975): 'Czech Republic'",,,"Sentence boundary between ""Czech"" and ""Republic""",FALSE,FALSE,TRUE,TRUE
-dev,11,"[1961, 1966): 'Czech'",LOC,Sentence,,,17,,FALSE,TRUE,FALSE,FALSE
-dev,12,"[1247, 1254): 'CHICAGO'",LOC,Tag,"[1247, 1254): 'CHICAGO'",ORG,13,Team,FALSE,TRUE,FALSE,FALSE
-dev,12,"[1266, 1276): 'CINCINNATI'",LOC,Tag,"[1266, 1276): 'CINCINNATI'",ORG,17,Sports team ,FALSE,TRUE,FALSE,FALSE
-dev,12,"[1290, 1298): 'MONTREAL'",LOC,Tag,"[1290, 1298): 'MONTREAL'",ORG,17,sports team,FALSE,TRUE,FALSE,FALSE
-dev,12,"[1314, 1326): 'PHILADELPHIA'",LOC,Tag,"[1314, 1326): 'PHILADELPHIA'",ORG,,Baseball team,FALSE,TRUE,TRUE,TRUE
-dev,12,"[1338, 1348): 'PITTSBURGH'",LOC,Tag,"[1338, 1348): 'PITTSBURGH'",ORG,15,baseball team ,FALSE,TRUE,FALSE,FALSE
-dev,12,"[1366, 1374): 'NEW YORK'",LOC,Tag,"[1366, 1374): 'NEW YORK'",ORG,16,baseball team ,FALSE,TRUE,FALSE,FALSE
-dev,12,"[1387, 1395): 'ST LOUIS'",LOC,Tag,"[1387, 1395): 'ST LOUIS'",ORG,,Home team for a baseball game,FALSE,FALSE,FALSE,TRUE
-dev,12,"[672, 679): 'DETROIT'",LOC,Tag,"[672, 679): 'DETROIT'",ORG,,Home team for a baseball game,FALSE,FALSE,FALSE,TRUE
-dev,12,"[691, 698): 'TORONTO'",LOC,Tag,"[691, 698): 'TORONTO'",ORG,14,baseball team ,FALSE,TRUE,FALSE,FALSE
-dev,12,"[712, 721): 'MILWAUKEE'",LOC,Tag,"[712, 721): 'MILWAUKEE'",ORG,,Home team for a baseball game,FALSE,FALSE,FALSE,TRUE
-dev,12,"[735, 740): 'TEXAS'",LOC,Tag,"[735, 740): 'TEXAS'",ORG,14,baseball team ,FALSE,TRUE,FALSE,FALSE
-dev,12,"[753, 763): 'CALIFORNIA'",LOC,Tag,"[753, 763): 'CALIFORNIA'",ORG,,Home team for a baseball game,FALSE,FALSE,FALSE,TRUE
-dev,12,"[774, 781): 'OAKLAND'",LOC,Tag,"[774, 781): 'OAKLAND'",ORG,,Home team for a baseball game,FALSE,FALSE,FALSE,TRUE
-dev,12,"[795, 802): 'SEATTLE'",LOC,Tag,"[795, 802): 'SEATTLE'",ORG,17,Sports team,FALSE,TRUE,FALSE,FALSE
-dev,12,"[88, 109): 'Major League Baseball'",MISC,Tag,"[88, 109): 'Major League Baseball'",ORG,14,organization ,FALSE,TRUE,FALSE,FALSE
-dev,12,"[232, 248): 'EASTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-dev,12,"[380, 396): 'CENTRAL DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-dev,12,"[519, 535): 'WESTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-dev,12,"[819, 835): 'EASTERN DIVISION",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-dev,12,"[962, 978): 'CENTRAL DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-dev,12,"[1095, 1111): 'WESTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-dev,12,"[819, 835): 'EASTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-dev,13,"[83, 95): 'Major League'",MISC,Sentence,"[83, 104): 'Major League Baseball'",,,"Sentence boundary between ""League"" and ""Baseball""",FALSE,TRUE,TRUE,TRUE
-dev,14,,,Missing,"[452, 459): 'Stadium'",LOC,,"""Stadium"" with a capital ""S"", referring to Arthur Ashe Stadium",FALSE,TRUE,TRUE,TRUE
-dev,15,"[41, 51): 'CUNNINGHAM'",PER,Token,"(33, 51]: 'RANDALL CUNNINGHAM'",,,"need to split on '-' ""FOOTBALL-RANDALL""",FALSE,FALSE,FALSE,TRUE
-dev,15,"[41, 51): 'CUNNINGHAM'",PER,Token,"(33,51] 'RANDALL CUNNINGHAM'",,14,,FALSE,TRUE,FALSE,FALSE
-dev,15,"[15, 40): 'AMERICAN FOOTBALL-RANDALL'",MISC,Token,"[33, 40): 'RANDALL'",PER,,"""FOOTBALL-RANDALL"" treated as a single token",FALSE,FALSE,TRUE,TRUE
-dev,15,"[41, 51): 'CUNNINGHAM'",PER,Token,"[33,51): 'RANDALL CUNNINGHAM'",MISC,,"Tokenizer treated ""FOOTBALL-RANDALL"" as a single token",FALSE,FALSE,FALSE,TRUE
-dev,15,"[15, 40): 'AMERICAN FOOTBALL-RANDALL'",MISC,Wrong,,,16, divisions of leagues not entities,TRUE,FALSE,FALSE,FALSE
-dev,16,"[414, 418): 'Wood'",PER,Sentence,"[407, 418): 'Willie Wood'",,17,,FALSE,TRUE,FALSE,FALSE
-dev,16,"[533, 538): 'Green'",PER,Sentence,"[529, 538): 'Ken Green'",,17,,FALSE,TRUE,FALSE,FALSE
-dev,20,"[5423, 5433): 'Fredericks'",PER,Sentence,"[5415, 5433): 'Frankie Fredericks'",,,Sentence boundary between first and last name,FALSE,FALSE,TRUE,TRUE
-dev,20,"[5423, 5433): 'Fredericks'",PER,Sentence,"[5415, 5433): 'Frankie Fredricks'",,17,,FALSE,TRUE,FALSE,FALSE
-dev,20,"[5650, 5665): 'Panayiotopoulos'",PER,Sentence,"[5643, 5665): 'George Panayiotopoulos'",,17,,FALSE,TRUE,FALSE,FALSE
-dev,20,"[90, 96): 'Berlin'",MISC,Sentence,"[90, 107): 'Berlin Grand Prix'",,16,,TRUE,FALSE,FALSE,FALSE
-dev,26,"[1381, 1386): 'India'",LOC,Tag,"[1381, 1386): 'India'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-dev,26,"[1389, 1397): 'Zimbabwe'",LOC,Tag,"[1389, 1397): 'Zimbabwe'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-dev,26,"[139, 148): 'Australia'",LOC,Tag,"[139, 148): 'Australia'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-dev,26,"[153, 162): 'Sri Lanka'",LOC,Tag,"[153, 162): 'Sri Lanka'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-dev,26,"[174, 183): 'Australia'",LOC,Tag,"[174, 183): 'Australia'",ORG,17,Cricket team,FALSE,TRUE,FALSE,FALSE
-dev,26,"[20, 29): 'AUSTRALIA'",LOC,Tag,"[20, 29): 'AUSTRALIA'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-dev,26,"[32, 41): 'SRI LANKA'",LOC,Tag,"[32, 41): 'SRI LANKA'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-dev,26,"[97, 103): 'Singer'",MISC,Sentence,"[97, 116): 'Singer World Series'",,17,,FALSE,TRUE,FALSE,FALSE
-dev,28,"[20, 29): 'AUSTRALIA'",LOC,Tag,"[20, 29): 'AUSTRALIA'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-dev,28,"[244, 253): 'Australia'",LOC,Tag,"[244, 253): 'Australia'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-dev,28,"[291, 297): 'Damien'",PER,Sentence,"[291, 306): 'Damien Flemming'",,17,,FALSE,TRUE,FALSE,FALSE
-dev,28,"[358, 365): 'Ponting'",PER,Sentence,"[352, 365): 'Ricky Ponting'",,17,,FALSE,TRUE,FALSE,FALSE
-dev,28,"[411, 416): 'Steve'",PER,Sentence,"[411, 422): 'Steve Waugh'",,17,,FALSE,TRUE,FALSE,FALSE
-dev,28,"[77, 86): 'Australia'",LOC,Tag,"[77, 86): 'Australia'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-dev,30,,,Missing,"[18, 21): 'NBP'",ORG,,NBP == National Bank of Poland,FALSE,FALSE,FALSE,TRUE
-dev,33,,,Missing,"[11, 16): 'NYMEX'",ORG,,NYMEX heating oil near session lows in pre-close.,FALSE,TRUE,FALSE,TRUE
-dev,33,,,Missing,"[1186, 1191): 'NYMEX'",ORG,,New York Mercantile Exchange,FALSE,TRUE,TRUE,TRUE
-dev,33,,,Missing,"[81, 86): 'NYMEX'",MISC,,"New York Mercantile Exchange, used as an adjective",FALSE,FALSE,FALSE,TRUE
-dev,35,"[70, 74): 'Mich'",LOC,Span,"[70, 75): 'Mich.'",,,Period on abbreviation at end of dateline,FALSE,FALSE,TRUE,TRUE
-dev,38,,,Missing,"[1011, 1016): 'MATIF'",ORG,,,TRUE,TRUE,TRUE,TRUE
-dev,38,,,Missing,"[735, 738): 'PMI'",MISC,,the PMI survey,FALSE,FALSE,TRUE,TRUE
-dev,38,"[2202, 2211): 'EUROBONDS'",MISC,Wrong,,,16,"Zach: Bond exchange market; Fred: ""Eurobond"" appears to be a generic term for a type of bond; see https://www.investopedia.com/terms/e/eurobond.asp",FALSE,TRUE,FALSE,FALSE
-dev,39,"[11, 23): 'Boxing-Bruno'",MISC,Token,"[18, 23): 'Bruno'",PER,17,,FALSE,TRUE,TRUE,FALSE
-dev,39,,MISC,Token,"[18, 23): 'Bruno'	",PER,,"Tokenizer treats ""Boxing-Bruno"" as one token",FALSE,TRUE,FALSE,TRUE
-dev,42,"[476, 539): 'Driefontein Consolidated and Gold Fields ' Kloof Gold Mining Co'",ORG,Span,"[476, 500): 'Driefontein Consolidated'",ORG,17,,TRUE,TRUE,TRUE,FALSE
-dev,42,,,Missing,"[505, 516): 'Gold Fields'",ORG,16,Description of two companies jointly owning a third company,TRUE,FALSE,FALSE,FALSE
-dev,42,,,Missing,"[519, 539): 'Kloof Gold Mining Co'",ORG,16,Description of two companies jointly owning a third company,TRUE,FALSE,FALSE,FALSE
-dev,59,,,Missing,"[2024, 2029): 'Comex'",MISC,,"""New York's Comex market""",FALSE,FALSE,TRUE,TRUE
-dev,60,"[1358, 1371): 'Tripoli-based'",MISC,Token,"[1358, 1365): 'Tripoli'",LOC,15,,FALSE,TRUE,FALSE,FALSE
-dev,61,"[3878, 3888): 'Whitewater'",LOC,Tag,"[3878, 3888): 'Whitewater'",MISC,16,Event: whitewater scandal,FALSE,TRUE,FALSE,FALSE
-dev,61,"[4515, 4524): 'Dow Jones'",MISC,Tag,"[4515, 4524): 'Dow Jones'",ORG,,Fred: See previous line,FALSE,FALSE,FALSE,TRUE
-dev,61,"[4614, 4620): 'Nasdaq'",MISC,Tag,"[4614, 4620): 'Nasdaq'",ORG,13,"Zach: CHECK: should this be ORG? ; Fred: Ambiguous, but there are four examples back-to-back, two tagged one way and two the other. Making everything ORG.",FALSE,TRUE,FALSE,FALSE
-dev,62,"[2553, 2564): 'First Union'",ORG,Span,"[2553, 2569): 'First Union bank'",ORG,17,,FALSE,TRUE,FALSE,FALSE
-dev,64,"[2571, 2575): 'AIDS'",MISC,Wrong,,,15,"Name of a disease, but disease idt counts ",FALSE,TRUE,FALSE,FALSE
-dev,65,"[1135, 1140): 'Louis'",MISC,Sentence,"(1130, 1140]: 'St. Louis'",LOC,16,Sentence boundary btw St. and Louis,TRUE,FALSE,FALSE,FALSE
-dev,65,"[1125, 1134): 'asset-St.'",MISC,Sentence,"[1131, 1140): 'St. Louis'",LOC,,Sentence boundary AND token problem,FALSE,FALSE,TRUE,TRUE
-dev,65,"[1125, 1134): 'asset-St.'",MISC,Token,"[1131, 1146): 'St. Louis based'",MISC,8,"[1125, 1133): 'asset-St' treated as a single token",TRUE,FALSE,FALSE,FALSE
-dev,65,"[1135, 1140): 'Louis'",MISC,Sentence,"[1131,1140) 'St. Louis' ",,17,,FALSE,TRUE,FALSE,FALSE
-dev,65,"[1125, 1134): 'asset-St.'",MISC,Sentence,"[1131,1140) 'St. Louis' ",LOC,17,Sentence and token. Should be 'asset-' 'st' '.' 'louis'  AND sentence break btween st and louis.  Also need to double check my span. ,FALSE,TRUE,FALSE,FALSE
-dev,65,"[592, 607): 'St. Louis-based'",MISC,Token,"[592, 601): 'St. Louis'",LOC,15,,FALSE,TRUE,FALSE,FALSE
-dev,65,"[1125, 1134): 'asset-St.'",MISC,Token,,,16,Asset-St. Treated as 1 token,TRUE,FALSE,FALSE,FALSE
-dev,77,"[14, 34): 'Computer Systems Inc'",ORG,Span,"[11, 34): 'Aw Computer Systems Inc'",ORG,16,,FALSE,TRUE,FALSE,FALSE
-dev,77,"[14, 34): 'Computer Systems Inc'",,Span,"[11, 34): 'Aw Computer Systems Inc'",,,,FALSE,TRUE,FALSE,TRUE
-dev,78,"[81, 85): 'Name'",MISC,Wrong,,,17,,TRUE,TRUE,TRUE,FALSE
-dev,80,"[716, 722): 'Gama'a'",MISC,Tag,"[716, 722): 'Gama'a'",ORG,17,,FALSE,TRUE,FALSE,FALSE
-dev,83,,,Missing,"[1718, 1726): 'Commerce'",ORG,9,,TRUE,FALSE,FALSE,FALSE
-dev,84,"[114, 120): 'NY Dow'",MISC,Tag,"[114, 120): 'NY Dow'",ORG,16,Fred: Stock market,FALSE,TRUE,FALSE,FALSE
-dev,84,"[1274, 1287): 'Raymond James'",PER,Tag,"[1274, 1287): 'Raymond James'",ORG,17,,FALSE,TRUE,FALSE,FALSE
-dev,84,"[195, 201): 'Nikkei'",MISC,Tag,"[195, 201): 'Nikkei'",ORG,,Fred: Stock market,FALSE,FALSE,FALSE,TRUE
-dev,84,"[273, 277): 'FTSE'",MISC,Tag,"[273, 277): 'FTSE'",ORG,,Fred: Stock market,FALSE,FALSE,FALSE,TRUE
-dev,86,"[306, 309): 'FTO'",ORG,Wrong,,,,Ticker symbol for Notional Guilder Bond Future; futures contracts not considered entities,FALSE,FALSE,TRUE,TRUE
-dev,86,"[923, 926): 'FTO'",ORG,Wrong,,,,Ticker symbol for Notional Guilder Bond Future; futures contracts not considered entities,FALSE,FALSE,FALSE,TRUE
-dev,87,,,Missing,"[181, 191): 'pro-Moscow'",MISC,,,FALSE,TRUE,TRUE,TRUE
-dev,87,,,Missing,"[595, 600): 'Cotti'",PER,,"powers there, "" said Cotti, who",TRUE,TRUE,TRUE,TRUE
-dev,89,,,Missing,"[1042, 1050): 'Armenian'",MISC,,,TRUE,TRUE,TRUE,TRUE
-dev,89,"[336, 347): 'Azerbaijani'",PER,Tag,"[336, 347): 'Azerbaijani'",MISC,17,,FALSE,TRUE,FALSE,FALSE
-dev,90,"[983, 991): 'Onarheim'",LOC,Tag,"[983, 991): 'Onarheim'",PER,17,,TRUE,TRUE,FALSE,FALSE
-dev,91,"[374, 377): 'AXE'",MISC,Tag,"[374, 377): 'AXE'",ORG,14,Fred: AXE is a brand name; see https://en.wikipedia.org/wiki/AXE_telephone_exchange,FALSE,TRUE,FALSE,FALSE
-dev,93,,MISC,Missing,"[1025, 1030): 'Timor'",LOC,,Indonesia's controversial Timor national car,FALSE,TRUE,FALSE,TRUE
-dev,93,"[794, 804): 'Philippine'",LOC,Tag,"[794, 804): 'Philippine'",MISC,16,Philippine government,TRUE,FALSE,FALSE,FALSE
-dev,99,"[1710, 1732): 'Burj al-Laqlaq Society'",LOC,Tag,"[1710, 1732): 'Burj al-Laqlaq Society'",ORG,16,,TRUE,TRUE,FALSE,FALSE
-dev,102,"[172, 178): 'Israel'",LOC,Tag,"[172, 178): 'Israel'",ORG,,Soccer team,FALSE,FALSE,FALSE,TRUE
-dev,102,"[182, 190): 'Bulgaria'",LOC,Tag,"[182, 190): 'Bulgaria'",ORG,7,Soccer team,TRUE,FALSE,FALSE,FALSE
-dev,102,"[19, 25): 'ISRAEL'",LOC,Tag,"[19, 25): 'ISRAEL'",ORG,,Soccer team,FALSE,FALSE,FALSE,TRUE
-dev,102,"[31, 39): 'BULGARIA'",LOC,Tag,"[31, 39): 'BULGARIA'",ORG,,Soccer team,FALSE,FALSE,FALSE,TRUE
-dev,103,"[19, 24): 'IRISH'",MISC,Tag,"[19, 24): 'IRISH'",ORG,13,Soccer team,FALSE,TRUE,FALSE,FALSE
-dev,103,"[214, 220): 'Alpine'",MISC,Tag,"[214, 220): 'Alpine'",ORG,15,ambiguous seems to ref an irish football team,TRUE,FALSE,FALSE,FALSE
-dev,103,"[673, 679): 'Eschen'",LOC,Tag,"[673, 679): 'Eschen'",MISC,10,"Proper noun as adjective: ""Ireland's visit to theÊEschenÊstadium""",TRUE,FALSE,FALSE,FALSE
-dev,104,"[96, 115): 'Republic of Ireland'",LOC,Tag,"[96, 115): 'Republic of Ireland'",ORG,16,Soccer team,FALSE,TRUE,FALSE,FALSE
-dev,106,"[33, 39): 'FAROES'",LOC,Tag,"[33, 39): 'FAROES'",ORG,17,"Could also possibly be MISC, I'm 50/50",TRUE,TRUE,FALSE,FALSE
-dev,108,"[543, 546): 'Aki'",PER,Tag,"[543, 546): 'Aki'",ORG,,,FALSE,FALSE,TRUE,TRUE
-dev,109,"[145, 152): 'England'",LOC,Tag,"[145, 152): 'England'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-dev,109,"[157, 165): 'Pakistan'",LOC,Tag,"[157, 165): 'Pakistan'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-dev,109,"[179, 186): 'England'",LOC,Tag,"[179, 186): 'England'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-dev,109,"[20, 27): 'ENGLAND'",LOC,Tag,"[20, 27): 'ENGLAND'",ORG,,,FALSE,FALSE,FALSE,TRUE
-dev,109,"[30, 38): 'PAKISTAN'",LOC,Tag,"[30, 38): 'PAKISTAN'",ORG,,,FALSE,FALSE,FALSE,TRUE
-dev,109,"[59, 69): 'BIRMINGHAM'",ORG,Tag,"[59, 69): 'BIRMINGHAM'",LOC,17,,TRUE,TRUE,TRUE,FALSE
-dev,109,,,Missing,"[765, 773): 'pakistan'",ORG,,Cricket team,FALSE,TRUE,TRUE,TRUE
-dev,110,"[2192, 2196): 'Jane'",PER,Sentence,"[2192, 2204): 'Jane Quigley'",,17,,FALSE,TRUE,FALSE,FALSE
-dev,110,"[2349, 2361): 'Samokhvalova'",PER,Sentence,"[2340, 2361): ''Svetlana Samokhvalova' ",,17,,FALSE,TRUE,FALSE,FALSE
-dev,110,"[2340, 2348): 'Svetlana'",PER,Sentence,"[2340, 2361): 'Svetlana Samokhvalova'",PER,,Sentence boundary between first and last names,FALSE,TRUE,FALSE,TRUE
-dev,110,"[2349, 2361): 'Samokhvalova'",PER,Sentence,"[2340, 2361): 'Svetlana Samokhvalova'",,,Sentence boundary between first and last name,FALSE,FALSE,TRUE,TRUE
-dev,110,"[2438, 2442): 'Rasa'",PER,Sentence,"[2438, 2452): 'Rasa Mazeikyte'",,17,,FALSE,TRUE,FALSE,FALSE
-dev,112,"[1702, 1710): 'New York'",LOC,Tag,"[1702, 1710): 'New York'",ORG,17,,FALSE,TRUE,FALSE,FALSE
-dev,112,,,Missing,"[2041, 2050): 'Ex-Yankee'",MISC,,,FALSE,TRUE,FALSE,TRUE
-dev,112,"[2973, 2980): 'Chicago'",LOC,Tag,"[2973, 2980): 'Chicago'",ORG,13,Baseball team,FALSE,TRUE,FALSE,FALSE
-dev,112,"[324, 329): 'Texas'",LOC,Tag,"[324, 329): 'Texas'",ORG,17,,FALSE,TRUE,FALSE,FALSE
-dev,112,"[3827, 3838): 'Kansas City'",LOC,Tag,"[3827, 3838): 'Kansas City'",ORG,,Kansas City Royals baseball team,FALSE,FALSE,FALSE,TRUE
-dev,112,"[536, 541): 'Texas'",LOC,Tag,"[536, 541): 'Texas'",ORG,17,,FALSE,TRUE,FALSE,FALSE
-dev,112,"[791, 798): 'Indians'",MISC,Tag,"[791, 798): 'Indians'",ORG,17,,FALSE,TRUE,FALSE,FALSE
-dev,112,"[900, 905): 'Texas'",LOC,Tag,"[900, 905): 'Texas'",ORG,14,Baseball team ,FALSE,TRUE,FALSE,FALSE
-dev,112,"[3804, 3807): 'ERA'",MISC,Wrong,,,17,,FALSE,TRUE,FALSE,FALSE
-dev,112,"[730, 733): 'RBI'",MISC,Wrong,,,,Run batted in,FALSE,FALSE,FALSE,TRUE
-dev,112,"[2962, 2965): 'RBI'",MISC,Wrong,,,,Runs batted in,FALSE,FALSE,FALSE,TRUE
-dev,112,"[2962, 2965): 'RBI'	",MISC,Wrong,,,,"Abbreviation for ""runs batted in"", which isn't a named entity",FALSE,FALSE,FALSE,TRUE
-dev,112,"[3804, 3807): 'ERA'",,Wrong,,,,"Abbreviation for ""earned run average"", which isn't a named entity",FALSE,FALSE,FALSE,TRUE
-dev,115,"[594, 602): 'Stirling'",ORG,Span,"[594, 609): 'Stirling County'",ORG,17,,TRUE,TRUE,FALSE,FALSE
-dev,116,"[19, 24): 'WALES'",LOC,Tag,"[19, 24): 'WALES'",ORG,14,Soccer team,FALSE,TRUE,FALSE,FALSE
-dev,118,"[271, 280): 'Leicester'",LOC,Tag,"[271, 280): 'Leicester'",ORG,,...coachÊBob DwyerÊon his league coaching debut withÊ[Leicester].,FALSE,TRUE,TRUE,TRUE
-dev,118,"[50, 55): 'DWYER'",ORG,Tag,"[50, 55): 'DWYER'",PER,17,,TRUE,TRUE,FALSE,FALSE
-dev,118,"[710, 720): 'Harlequins'",LOC,Tag,"[710, 720): 'Harlequins'",ORG,,Harlequin F.C.,FALSE,TRUE,TRUE,TRUE
-dev,124,"[597, 605): 'Al Unser'",PER,Span,"[597, 608): 'Al Unser Jr'",PER,16,,TRUE,FALSE,FALSE,FALSE
-dev,125,"[188, 197): 'World Cup'",MISC,Span,"[183, 187): '1998 World Cup'",,,,FALSE,TRUE,FALSE,TRUE
-dev,126,"[105, 117): 'South Africa'",LOC,Tag,"[105, 117): 'South Africa'",ORG,,Rugby team,FALSE,FALSE,FALSE,TRUE
-dev,126,"[2795, 2807): 'South Africa'",LOC,Tag,"[2795, 2807): 'South Africa'",ORG,,Rugby team,FALSE,FALSE,FALSE,TRUE
-dev,126,"[3190, 3201): 'New Zealand'",LOC,Tag,"[3190, 3201): 'New Zealand'",ORG,,Rugby team,FALSE,FALSE,FALSE,TRUE
-dev,126,"[350, 361): 'New Zealand'",LOC,Tag,"[350, 361): 'New Zealand'",ORG,,Rugby team,FALSE,FALSE,FALSE,TRUE
-dev,126,"[523, 534): 'New Zealand'",LOC,Tag,"[523, 534): 'New Zealand'",ORG,,Rugby team,FALSE,FALSE,FALSE,TRUE
-dev,127,"[24, 36): 'SOUTH AFRICA'",LOC,Tag,"[24, 36): 'SOUTH AFRICA'",ORG,13,Rugby team,FALSE,TRUE,FALSE,FALSE
-dev,129,"[19, 29): 'MAURITANIA'",LOC,Tag,"[19, 29): 'MAURITANIA'",ORG,14,Soccer team,FALSE,TRUE,FALSE,FALSE
-dev,129,"[40, 45): 'BENIN'",LOC,Tag,"[40, 45): 'BENIN'",ORG,17,Soccer team,FALSE,TRUE,FALSE,FALSE
-dev,130,"[180, 183): 'Rad'",ORG,Span,"[180, 187): 'Rad (B)'",,,,FALSE,FALSE,TRUE,TRUE
-dev,135,"[104, 112): 'Portugal'",LOC,Tag,"[104, 112): 'Portugal'",ORG,,Soccer team,FALSE,FALSE,FALSE,TRUE
-dev,135,"[19, 26): 'ARMENIA'",LOC,Tag,"[19, 26): 'ARMENIA'",ORG,,Soccer team,FALSE,FALSE,TRUE,TRUE
-dev,135,"[31, 39): 'PORTUGAL'",LOC,Tag,"[31, 39): 'PORTUGAL'",ORG,16,Soccer team,FALSE,TRUE,FALSE,FALSE
-dev,135,"[92, 99): 'Armenia'",LOC,Tag,"[92, 99): 'Armenia'",ORG,,Soccer team,FALSE,FALSE,FALSE,TRUE
-dev,136,"[19, 29): 'AZERBAIJAN'",LOC,Tag,"[19, 29): 'AZERBAIJAN'",ORG,13,soccer team,FALSE,TRUE,FALSE,FALSE
-dev,138,"[19, 25): 'SWEDEN'",LOC,Tag,"[19, 25): 'SWEDEN'",ORG,17,Soccer team,FALSE,TRUE,FALSE,FALSE
-dev,138,"[31, 37): 'LATVIA'",LOC,Tag,"[31, 37): 'LATVIA'",ORG,,Soccer team,FALSE,FALSE,FALSE,TRUE
-dev,138,"[86, 92): 'Sweden'",LOC,Tag,"[86, 92): 'Sweden'",ORG,,Soccer team,FALSE,FALSE,FALSE,TRUE
-dev,138,"[98, 104): 'Latvia'",LOC,Tag,"[98, 104): 'Latvia'",ORG,,Soccer team,FALSE,FALSE,FALSE,TRUE
-dev,139,"[19, 26): 'BELARUS'",LOC,Tag,"[19, 26): 'BELARUS'",ORG,16,National soccer team,FALSE,TRUE,FALSE,FALSE
-dev,140,"[128, 136): 'European'",MISC,Span,"[128, 145): 'European Under-21'",,,https://en.wikipedia.org/wiki/UEFA_European_Under-21_Championship,FALSE,FALSE,TRUE,TRUE
-dev,141,,,Missing,"[1279, 1286): 'Jansher'",PER,,,TRUE,TRUE,TRUE,TRUE
-dev,144,"[19, 24): 'SPAIN'",LOC,Tag,"[19, 24): 'SPAIN'",ORG,17,Slightly ambiguous,FALSE,TRUE,FALSE,FALSE
-dev,146,"[229, 242): 'United States'",LOC,Tag,"[229, 242): 'United States'",ORG,,Tennis team,FALSE,FALSE,FALSE,TRUE
-dev,146,"[246, 257): 'Netherlands'",LOC,Tag,"[246, 257): 'Netherlands'",ORG,,Tennis team,FALSE,FALSE,TRUE,TRUE
-dev,146,"[258, 272): 'Czech Republic'",LOC,Tag,"[258, 272): 'Czech Republic'",ORG,,Tennis team,FALSE,FALSE,FALSE,TRUE
-dev,146,"[276, 283): 'Germany'",LOC,Tag,"[276, 283): 'Germany'",ORG,,Tennis team,FALSE,FALSE,FALSE,TRUE
-dev,146,"[284, 290): 'France'",LOC,Tag,"[284, 290): 'France'",ORG,,Tennis team,FALSE,FALSE,FALSE,TRUE
-dev,146,"[294, 299): 'Japan'",LOC,Tag,"[294, 299): 'Japan'",ORG,,Tennis team,FALSE,FALSE,FALSE,TRUE
-dev,146,"[300, 305): 'Spain'",LOC,Tag,"[300, 305): 'Spain'",ORG,,Tennis team,FALSE,FALSE,FALSE,TRUE
-dev,146,"[309, 316): 'Belgium'",LOC,Tag,"[309, 316): 'Belgium'",ORG,,Tennis team,FALSE,FALSE,FALSE,TRUE
-dev,146,"[409, 416): 'Austria'",LOC,Tag,"[409, 416): 'Austria'",ORG,,Tennis team,FALSE,FALSE,FALSE,TRUE
-dev,146,"[420, 427): 'Croatia'",LOC,Tag,"[420, 427): 'Croatia'",ORG,,Tennis team,FALSE,FALSE,TRUE,TRUE
-dev,146,"[428, 439): 'Switzerland'",LOC,Tag,"[428, 439): 'Switzerland'",ORG,,Tennis team,FALSE,FALSE,TRUE,TRUE
-dev,146,"[443, 458): 'Slovak Republic'",LOC,Tag,"[443, 458): 'Slovak Republic'",ORG,,Tennis team,FALSE,FALSE,FALSE,TRUE
-dev,146,"[459, 468): 'Argentina'",LOC,Tag,"[459, 468): 'Argentina'",ORG,,Tennis team,FALSE,FALSE,FALSE,TRUE
-dev,146,"[472, 483): 'South Korea'",LOC,Tag,"[472, 483): 'South Korea'",ORG,,Tennis team,FALSE,FALSE,TRUE,TRUE
-dev,146,"[484, 493): 'Australia'",LOC,Tag,"[484, 493): 'Australia'",ORG,,Tennis team,FALSE,FALSE,TRUE,TRUE
-dev,146,"[497, 509): 'South Africa'",LOC,Tag,"[497, 509): 'South Africa'",ORG,,Tennis team,FALSE,FALSE,FALSE,TRUE
-dev,147,"[179, 183): 'U.S.'",LOC,Tag,"[179, 183): 'U.S.'",ORG,,U.S. soccer team,FALSE,FALSE,FALSE,TRUE
-dev,147,"[255, 266): 'El Salvador'",LOC,Tag,"[255, 266): 'El Salvador'",ORG,,El Salvadorean soccer team,FALSE,FALSE,FALSE,TRUE
-dev,147,"[29, 40): 'EL SALVADOR'",LOC,Tag,"[29, 40): 'EL SALVADOR'",ORG,9,U.S. BEAT EL SALVADOR 3-1.,TRUE,FALSE,FALSE,FALSE
-dev,147,"[73, 86): 'United States'",LOC,Tag,"[73, 86): 'United States'",ORG,,TheÊUnited StatesÊbeatÊEl SalvadorÊ3-1,FALSE,FALSE,FALSE,TRUE
-dev,147,"[92, 103): 'El Salvador'",LOC,Tag,"[92, 103): 'El Salvador'",ORG,,TheÊUnited StatesÊbeatÊEl SalvadorÊ3-1,FALSE,FALSE,FALSE,TRUE
-dev,148,"[1266, 1273): 'CHICAGO'",LOC,Tag,"[1266, 1273): 'CHICAGO'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-dev,148,"[1285, 1295): 'PITTSBURGH'",LOC,Tag,"[1285, 1295): 'PITTSBURGH'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-dev,148,"[1313, 1321): 'NEW YORK'",LOC,Tag,"[1313, 1321): 'NEW YORK'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-dev,148,"[1333, 1343): 'CINCINNATI'",LOC,Tag,"[1333, 1343): 'CINCINNATI'",ORG,17,,FALSE,TRUE,FALSE,FALSE
-dev,148,"[1359, 1371): 'PHILADELPHIA'",LOC,Tag,"[1359, 1371): 'PHILADELPHIA'",ORG,16,,FALSE,TRUE,FALSE,FALSE
-dev,148,"[1385, 1393): 'MONTREAL'",LOC,Tag,"[1385, 1393): 'MONTREAL'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-dev,148,"[1406, 1414): 'ST LOUIS'",LOC,Tag,"[1406, 1414): 'ST LOUIS'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-dev,148,"[669, 676): 'DETROIT'",LOC,Tag,"[669, 676): 'DETROIT'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-dev,148,"[690, 697): 'SEATTLE'",LOC,Tag,"[690, 697): 'SEATTLE'",ORG,14,team,FALSE,TRUE,FALSE,FALSE
-dev,148,"[709, 716): 'TORONTO'",LOC,Tag,"[709, 716): 'TORONTO'",ORG,13,team,FALSE,TRUE,FALSE,FALSE
-dev,148,"[730, 739): 'MILWAUKEE'",LOC,Tag,"[730, 739): 'MILWAUKEE'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-dev,148,"[753, 758): 'TEXAS'",LOC,Tag,"[753, 758): 'TEXAS'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-dev,148,"[769, 776): 'OAKLAND'",LOC,Tag,"[769, 776): 'OAKLAND'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-dev,148,"[789, 799): 'CALIFORNIA'",LOC,Tag,"[789, 799): 'CALIFORNIA'",ORG,14,,FALSE,TRUE,FALSE,FALSE
-dev,148,"[975, 991): 'CENTRAL DIVISION'",MISC,Wrong,,,16,Divisions donÕt count ,FALSE,TRUE,FALSE,FALSE
-dev,148,"[228, 244): 'EASTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-dev,148,"[376, 392): 'CENTRAL DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-dev,148,"[514, 530): 'WESTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-dev,148,"[816, 832): 'EASTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-dev,148,"[1112, 1128): 'WESTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-dev,149,"[81, 93): 'Major League'",MISC,Sentence,"[81, 102): 'Major League Baseball'",,,"Sentence boundary between ""League"" and ""Baseball""",FALSE,FALSE,TRUE,TRUE
-dev,150,"[2463, 2470): 'Chicago'",LOC,Tag,"[2463, 2470): 'Chicago'",ORG,,,FALSE,FALSE,TRUE,TRUE
-dev,150,"[2533, 2540): 'Atlanta'",LOC,Tag,"[2533, 2540): 'Atlanta'",ORG,,Atlanta Braves,FALSE,FALSE,FALSE,TRUE
-dev,150,"[3115, 3123): 'Montreal'",LOC,Tag,"[3115, 3123): 'Montreal'",ORG,17,,FALSE,TRUE,FALSE,FALSE
-dev,150,"[3142, 3150): 'Montreal'",LOC,Tag,"[3142, 3150): 'Montreal'",ORG,17,,FALSE,TRUE,FALSE,FALSE
-dev,150,"[101, 104): 'ERA'",MISC,Wrong,,,17,,FALSE,TRUE,FALSE,FALSE
-dev,150,"[40, 43): 'ERA'",MISC,Wrong,,,15,,FALSE,TRUE,FALSE,FALSE
-dev,150,"[164, 167): 'RBI'",MISC,Wrong,,,,Runs batted in,FALSE,FALSE,FALSE,TRUE
-dev,150,"[3709, 3712): 'RBI'",MISC,Wrong,,,,Runs batted in,FALSE,FALSE,FALSE,TRUE
-dev,150,"[3953, 3956): 'RBI'",MISC,Wrong,,,,Runs batted in,FALSE,FALSE,FALSE,TRUE
-dev,150,"[4459, 4462): 'RBI'",MISC,Wrong,,,,Runs batted in,FALSE,FALSE,FALSE,TRUE
-dev,150,"[4617, 4620): 'RBI'",MISC,Wrong,,,,Runs batted in,FALSE,FALSE,FALSE,TRUE
-dev,152,,,Missing,"[41, 44): 'WBO'",ORG,,,FALSE,FALSE,FALSE,TRUE
-dev,153,"[100, 107): 'Austria'",LOC,Tag,"[100, 107): 'Austria'",ORG,,Soccer team,FALSE,FALSE,FALSE,TRUE
-dev,153,,,Missing,"[1465, 1470): 'Scots'",MISC,,,FALSE,TRUE,TRUE,TRUE
-dev,153,"[163, 171): 'Scotland'",LOC,Tag,"[163, 171): 'Scotland'",ORG,,Soccer team,FALSE,FALSE,FALSE,TRUE
-dev,153,"[1651, 1658): 'Austria'",LOC,Tag,"[1651, 1658): 'Austria'",ORG,,Soccer team,FALSE,FALSE,FALSE,TRUE
-dev,153,"[1890, 1898): 'Scotland'",LOC,Tag,"[1890, 1898): 'Scotland'",ORG,,Soccer team,FALSE,FALSE,FALSE,TRUE
-dev,153,"[19, 26): 'AUSTRIA'",LOC,Tag,"[19, 26): 'AUSTRIA'",ORG,,Soccer team,FALSE,FALSE,FALSE,TRUE
-dev,153,"[307, 315): 'Scotland'",LOC,Tag,"[307, 315): 'Scotland'",ORG,,Soccer team,FALSE,FALSE,FALSE,TRUE
-dev,153,"[330, 337): 'Belarus'",LOC,Tag,"[330, 337): 'Belarus'",ORG,,Soccer team,FALSE,FALSE,FALSE,TRUE
-dev,153,"[36, 44): 'SCOTLAND'",LOC,Tag,"[36, 44): 'SCOTLAND'",ORG,17,Soccer team,FALSE,TRUE,TRUE,FALSE
-dev,153,"[418, 425): 'Austria'",LOC,Tag,"[418, 425): 'Austria'",ORG,,Soccer team,FALSE,FALSE,FALSE,TRUE
-dev,153,"[786, 794): 'Scotland'",LOC,Tag,"[786, 794): 'Scotland'",ORG,,Soccer team,FALSE,FALSE,FALSE,TRUE
-dev,153,"[886, 894): 'Scotland'",LOC,Tag,"[886, 894): 'Scotland'",ORG,,Soccer team,FALSE,FALSE,FALSE,TRUE
-dev,155,"[19, 25): 'FRANCE'",LOC,Tag,"[19, 25): 'FRANCE'",ORG,13,,FALSE,TRUE,FALSE,FALSE
-dev,156,"[19, 25): 'FRANCE'",LOC,Tag,"[19, 25): 'FRANCE'",ORG,17,,FALSE,TRUE,FALSE,FALSE
-dev,157,"[39, 45): 'TURKEY'",LOC,Tag,"[39, 45): 'TURKEY'",ORG,17,,FALSE,TRUE,FALSE,FALSE
-dev,158,,,Missing,"[42, 56): 'FIRST DIVISION'",MISC,,,FALSE,FALSE,FALSE,TRUE
-dev,158,"[120, 128): 'division'",MISC,Wrong,,,16, divisions of leagues not entities,TRUE,FALSE,FALSE,FALSE
-dev,159,,,Missing,"[37, 51): 'FIRST DIVISION'",MISC,,,FALSE,FALSE,FALSE,TRUE
-dev,159,"[114, 122): 'division'",MISC,Wrong,,,16, divisions of leagues not entities,TRUE,FALSE,FALSE,FALSE
-dev,160,"[32, 38): 'TURKEY'",LOC,Tag,"[32, 38): 'TURKEY'",ORG,16,Zach: Soccer nat team,FALSE,TRUE,FALSE,FALSE
-dev,161,"[104, 112): 'Scotland'",LOC,Tag,"[104, 112): 'Scotland'",ORG,,Soccer team,FALSE,FALSE,FALSE,TRUE
-dev,161,"[19, 26): 'AUSTRIA'",LOC,Tag,"[19, 26): 'AUSTRIA'",ORG,,Soccer team,FALSE,FALSE,FALSE,TRUE
-dev,161,"[41, 49): 'SCOTLAND'",LOC,Tag,"[41, 49): 'SCOTLAND'",ORG,,Soccer team,FALSE,FALSE,FALSE,TRUE
-dev,161,"[92, 99): 'Austria'",LOC,Tag,"[92, 99): 'Austria'",ORG,,Soccer team,FALSE,FALSE,FALSE,TRUE
-dev,163,"[124, 130): 'Brazil'",LOC,Tag,"[124, 130): 'Brazil'",ORG,,Fred: National soccer team,FALSE,FALSE,FALSE,TRUE
-dev,163,"[190, 201): 'Netherlands'",LOC,Tag,"[190, 201): 'Netherlands'",ORG,,Fred: National soccer team,FALSE,FALSE,FALSE,TRUE
-dev,163,"[256, 262): 'Brazil'",LOC,Tag,"[256, 262): 'Brazil'",ORG,,Fred: National soccer team,FALSE,FALSE,FALSE,TRUE
-dev,163,"[94, 109): 'The Netherlands'",LOC,Tag,"[94, 109): 'The Netherlands'",ORG,16,Zach: Nat soccer team,FALSE,TRUE,FALSE,FALSE
-dev,165,"[25, 45): 'TATTERSALLS BREEDERS'",MISC,Span,"[25, 52): 'TATTERSALLS BREEDERS STAKES'",MISC,17,,TRUE,TRUE,TRUE,FALSE
-dev,165,"[25, 45): 'TATTERSALLS BREEDERS'	",MISC,Span,"[25, 52): 'TATTERSALLS BREEDERS STAKES'	",,,,FALSE,FALSE,FALSE,TRUE
-dev,165,"[114, 120): 'Stakes'",MISC,Sentence,"[93, 120): 'Tattersalls Breeders Stakes'",,17,,FALSE,TRUE,FALSE,FALSE
-dev,165,"[114, 120): 'Stakes'",,Wrong,,,,See previous row,FALSE,FALSE,FALSE,TRUE
-dev,166,"[163, 172): 'World Cup'",MISC,Span,"[158, 172): '1998 World Cup'",MISC,,,FALSE,TRUE,TRUE,TRUE
-dev,170,"[1363, 1373): 'Red Shirts'",MISC,Tag,"[1363, 1373): 'Red Shirts'",ORG,13,"""1860- Giuseppe Garibaldi leading his "" Red Shirts "" seized Naples in the Italian war of liberation against the Austrians""",FALSE,TRUE,FALSE,FALSE
-dev,170,"[488, 494): 'Eugene'",ORG,Tag,"[488, 494): 'Eugene'",PER,16,,TRUE,TRUE,TRUE,FALSE
-dev,172,,,Missing,"[969, 982): 'Conservatives'",MISC,,Members of the Conservative party,FALSE,TRUE,TRUE,TRUE
-dev,175,"[252, 264): 'London-based'",MISC,Token,"[252, 258): 'London'",LOC,15,,FALSE,TRUE,FALSE,FALSE
-dev,178,,,Missing,"[105, 115): 'Afrikaners'",MISC,7,,TRUE,FALSE,FALSE,FALSE
-dev,178,"[105, 115): 'Afrikaners'",,Missing,,MISC,,,FALSE,FALSE,FALSE,TRUE
-dev,180,"[687, 699): 'Bosnian Serb'",MISC,Both,"[687, 708): 'Bosnian Serb republic'",LOC,15,Fred: Appears to be a reference to https://en.wikipedia.org/wiki/Republika_Srpska,FALSE,TRUE,FALSE,FALSE
-dev,181,"[1761, 1774): 'Moscow-backed'",MISC,Token,"[1761, 1767): 'Moscow'",LOC,15,I think this needs to be seperated,FALSE,TRUE,FALSE,FALSE
-dev,182,"[662, 670): 'division'",MISC,Wrong,,,17,,TRUE,TRUE,FALSE,FALSE
-dev,185,"[54, 62): 'SANTIAGO'",PER,Tag,"[54, 62): 'SANTIAGO'",LOC,17,,TRUE,TRUE,TRUE,FALSE
-dev,191,"[1031, 1037): 'Korean'",MISC,Span,"[1031, 1041): 'Korean War'",,,,FALSE,TRUE,TRUE,TRUE
-dev,191,"[1031, 1037): 'Korean'",,Span,"[1031, 1041): 'Korean War'",MISC,13,,TRUE,FALSE,FALSE,FALSE
-dev,191,"[660, 666): 'Korean'",MISC,Span,"[660, 670): 'Korean War'",MISC,16,,FALSE,TRUE,FALSE,FALSE
-dev,194,"[537, 544): 'Chinese'",MISC,Both,"[537, 556): 'Chinese Nationalist'",ORG,16,,FALSE,TRUE,FALSE,FALSE
-dev,194,"[537, 544): 'Chinese'",MISC,Span,"[537, 556): 'Chinese Nationalist'",,,Kuomintang party,FALSE,TRUE,TRUE,TRUE
-dev,194,"[537, 544): 'Chinese'",,Span,"[537, 556): 'Chinese Nationalist'",MISC,9,Reference to Kuomintang Party as an adjective,TRUE,FALSE,FALSE,FALSE
-dev,198,"[39, 47): 'aid-U.N.'",MISC,Token,"[43, 47): 'U.N.'",ORG,17,,FALSE,TRUE,TRUE,FALSE
-dev,199,,,Missing,"[106, 122): 'Turkish-operated'",MISC,,,TRUE,TRUE,TRUE,TRUE
-dev,199,"[139, 147): 'Bahraini'",LOC,Tag,"[139, 147): 'Bahraini'",MISC,,,FALSE,TRUE,TRUE,TRUE
-dev,199,"[39, 47): 'Bahraini'",LOC,Tag,"[39, 47): 'Bahraini'",MISC,,,FALSE,TRUE,TRUE,TRUE
-dev,200,,,Missing,"[1241, 1255): 'KDP-controlled'",MISC,,,TRUE,TRUE,TRUE,TRUE
-dev,204,"[160, 171): 'Lilac Falls'",LOC,Span,"[160, 177): 'Lilac Falls Motel'",LOC,15,Motel is capitolized,TRUE,FALSE,FALSE,FALSE
-dev,206,"[2266, 2273): 'Marines'",MISC,Tag,"[2266, 2273): 'Marines'",ORG,17,branch of millitary,FALSE,TRUE,FALSE,FALSE
-dev,206,"[458, 471): 'Mediterranean'",MISC,Tag,"[458, 471): 'Mediterranean'",LOC,,"""Enterprise was in the eastern Mediterranean""",FALSE,TRUE,FALSE,TRUE
-dev,211,,,Missing,"[11, 15): 'Nato'",ORG,,,TRUE,TRUE,FALSE,TRUE
-dev,214,"[1643, 1648): 'Oscar'",PER,Tag,"[1643, 1648): 'Oscar'",MISC,16,,FALSE,TRUE,FALSE,FALSE
-dev,214,,,Missing,"[75, 81): 'VENICE'",LOC,13,,TRUE,FALSE,FALSE,FALSE
-test,0,"[19, 24): 'JAPAN'",LOC,Tag,"[19, 24): 'JAPAN'",ORG,14,Soccer team,FALSE,TRUE,FALSE,FALSE
-test,0,"[40, 45): 'CHINA'",PER,Tag,"[40, 45): 'CHINA'",LOC,16,,TRUE,FALSE,FALSE,FALSE
-test,1,"[42, 47): 'ITALY'",LOC,Tag,"[42, 47): 'ITALY'",ORG,17,Soccer team,FALSE,TRUE,FALSE,FALSE
-test,2,"[35, 40): 'JAPAN'",LOC,Tag,"[35, 40): 'JAPAN'",ORG,17,Soccer team ,FALSE,TRUE,FALSE,FALSE
-test,3,"[21, 37): 'SKIING-WORLD CUP'",MISC,Token,"[28, 37): 'WORLD CUP'",MISC,,,FALSE,FALSE,FALSE,TRUE
-test,3,"[21, 37): 'SKIING-WORLD CUP'",MISC,Token,"[28,37)'WORLD CUP'",,17,CHECK span later,FALSE,TRUE,FALSE,FALSE
-test,4,"[141, 146): 'Japan'",LOC,Tag,"[141, 146): 'Japan'",ORG,7,,TRUE,FALSE,FALSE,FALSE
-test,4,"[149, 154): 'Syria'",LOC,Tag,"[149, 154): 'Syria'",ORG,7,,TRUE,FALSE,FALSE,FALSE
-test,4,"[181, 186): 'Japan'",LOC,Tag,"[181, 186): 'Japan'",ORG,,Soccer team,FALSE,FALSE,FALSE,TRUE
-test,4,"[232, 237): 'Syria'",LOC,Tag,"[232, 237): 'Syria'",ORG,,Soccer team,FALSE,FALSE,FALSE,TRUE
-test,4,"[276, 281): 'China'",LOC,Tag,"[276, 281): 'China'",ORG,,Soccer team,FALSE,FALSE,FALSE,TRUE
-test,4,"[284, 294): 'Uzbekistan'",,Tag,"[284, 294): 'Uzbekistan'",ORG,12,Soccer team,TRUE,FALSE,FALSE,FALSE
-test,4,"[462, 472): 'Uzbekistan'",LOC,Tag,"[462, 472): 'Uzbekistan'",ORG,,Soccer team,FALSE,FALSE,FALSE,TRUE
-test,4,"[487, 492): 'Japan'",LOC,Tag,"[487, 492): 'Japan'",ORG,,,FALSE,FALSE,FALSE,TRUE
-test,4,"[507, 512): 'Syria'",LOC,Tag,"[507, 512): 'Syria'",ORG,,,FALSE,FALSE,FALSE,TRUE
-test,4,"[507, 512): 'Syria'	",LOC,Tag,"[507, 512): 'Syria'	",ORG,,Soccer team,FALSE,FALSE,FALSE,TRUE
-test,4,"[527, 532): 'China'",LOC,Tag,"[527, 532): 'China'",ORG,8,Soccer team,TRUE,FALSE,FALSE,FALSE
-test,5,"[213, 221): 'Pakistan'",LOC,Tag,"[213, 221): 'Pakistan'",ORG,13,team,FALSE,TRUE,FALSE,FALSE
-test,5,"[31, 42): 'NEW ZEALAND'",LOC,Tag,"[31, 42): 'NEW ZEALAND'",ORG,15,cricket team,FALSE,TRUE,FALSE,FALSE
-test,6,"[88, 110): 'English F.A. Challenge'",MISC,Sentence,"[88, 114): 'English F.A. Challenge Cup'",,17,,FALSE,TRUE,FALSE,FALSE
-test,11,"[495, 503): 'Desvonde'",PER,Sentence,"[495, 509): 'Desvonde Botes'",,17,,FALSE,TRUE,FALSE,FALSE
-test,11,"[504, 509): 'Botes'",PER,Sentence,"[495, 509): 'Desvonde Botes'",PER,,Sentence boundary between first and last name,FALSE,FALSE,TRUE,TRUE
-test,15,"[1241, 1250): 'Australia'",LOC,Tag,"[1241, 1250): 'Australia'",ORG,,"Australian cricket team: ""Australia won by five wickets.""",FALSE,FALSE,FALSE,TRUE
-test,15,"[32, 43): 'WEST INDIES'",LOC,Tag,"[32, 43): 'WEST INDIES'",ORG,17,Cricket team,FALSE,TRUE,FALSE,FALSE
-test,16,"[100, 111): 'West Indies'",LOC,Tag,"[100, 111): 'West Indies'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-test,16,"[20, 29): 'AUSTRALIA'",LOC,Tag,"[20, 29): 'AUSTRALIA'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-test,16,"[217, 228): 'West Indies'",LOC,Tag,"[217, 228): 'West Indies'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-test,16,"[284, 293): 'Australia'",LOC,Tag,"[284, 293): 'Australia'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-test,16,"[35, 46): 'WEST INDIES'",LOC,Tag,"[35, 46): 'WEST INDIES'",ORG,17,Cricket team,FALSE,TRUE,FALSE,FALSE
-test,16,"[85, 94): 'Australia'",LOC,Tag,"[85, 94): 'Australia'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-test,17,"[188, 197): 'Australia'",LOC,Tag,"[188, 197): 'Australia'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-test,17,"[20, 31): 'WEST INDIES'",LOC,Tag,"[20, 31): 'WEST INDIES'",ORG,17,Cricket team,FALSE,TRUE,FALSE,FALSE
-test,17,"[60, 69): 'AUSTRALIA'",LOC,Tag,"[60, 69): 'AUSTRALIA'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-test,17,"[92, 103): 'West Indies'",LOC,Tag,"[92, 103): 'West Indies'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-test,18,"[143, 151): 'Tasmania'",LOC,Tag,"[143, 151): 'Tasmania'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-test,18,"[156, 164): 'Victoria'",LOC,Tag,"[156, 164): 'Victoria'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-test,18,"[194, 202): 'Tasmania'",LOC,Tag,"[194, 202): 'Tasmania'",ORG,17,Cricket team,FALSE,TRUE,FALSE,FALSE
-test,18,"[20, 36): 'SHEFFIELD SHIELD'",MISC,Tag,"[20, 36): 'SHEFFIELD SHIELD'",ORG,17,Cricket team,FALSE,TRUE,FALSE,FALSE
-test,20,"[20, 31): 'WEST INDIES'",LOC,Tag,"[20, 31): 'WEST INDIES'",ORG,17,Cricket team,FALSE,TRUE,FALSE,FALSE
-test,20,"[230, 239): 'Australia'",LOC,Tag,"[230, 239): 'Australia'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-test,20,"[247, 256): 'Melbourne'",LOC,Span,"[247, 271): 'Melbourne Cricket Ground'",,,,FALSE,FALSE,TRUE,TRUE
-test,20,"[290, 299): 'Australia'",LOC,Tag,"[290, 299): 'Australia'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-test,20,"[482, 493): 'West Indies'",LOC,Tag,"[482, 493): 'West Indies'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-test,21,"[713, 718): 'Indra'",PER,Sentence,"[713, 725): 'Indra Wijaya'",,17,,FALSE,TRUE,FALSE,FALSE
-test,22,"[19, 23): 'ARAB'",MISC,Both,"[19, 35): 'ARAB CONTRACTORS'",ORG,17,,FALSE,TRUE,FALSE,FALSE
-test,22,,,Missing,"[299, 310): 'Contractors'",ORG,,,FALSE,TRUE,TRUE,TRUE
-test,22,"[299, 310): 'Contractors'",,Missing,,ORG,,"short for ""Arab Contractors""",FALSE,FALSE,FALSE,TRUE
-test,23,"[1098, 1105): 'BUFFALO'",LOC,Tag,"[1098, 1105): 'BUFFALO'",ORG,15,,FALSE,TRUE,FALSE,FALSE
-test,23,"[1142, 1152): 'WASHINGTON'",LOC,Tag,"[1142, 1152): 'WASHINGTON'",ORG,,Hockey team,TRUE,TRUE,TRUE,TRUE
-test,23,"[1153, 1161): 'MONTREAL'",ORG,Tag,"[1153, 1161): 'MONTREAL'",ORG,14,,FALSE,TRUE,FALSE,FALSE
-test,23,"[1165, 1172): 'CHICAGO'",LOC,Tag,"[1165, 1172): 'CHICAGO'",ORG,,Hockey team,FALSE,FALSE,FALSE,TRUE
-test,23,"[1189, 1195): 'DALLAS'",LOC,Tag,"[1189, 1195): 'DALLAS'",ORG,,Hockey team,FALSE,FALSE,FALSE,TRUE
-test,23,"[1208, 1216): 'COLORADO'",LOC,Tag,"[1208, 1216): 'COLORADO'",ORG,,Hockey team,FALSE,FALSE,FALSE,TRUE
-test,23,"[1227, 1235): 'EDMONTON'",LOC,Tag,"[1227, 1235): 'EDMONTON'",ORG,,Hockey team,FALSE,FALSE,FALSE,TRUE
-test,23,"[628, 637): 'TAMPA BAY'",ORG,Tag,"[628, 637): 'TAMPA BAY'",ORG,14,,FALSE,TRUE,FALSE,FALSE
-test,23,"[94, 109): 'National Hockey'",ORG,Sentence,"[94, 116): 'National Hockey League'",,17,,TRUE,TRUE,TRUE,FALSE
-test,23,"[673, 689): 'CENTRAL DIVISION'",MISC,Wrong,,,17,,FALSE,TRUE,FALSE,FALSE
-test,24,"[227, 233): 'League'",ORG,Sentence,"[211, 233): 'National Hockey League'",,17,,FALSE,TRUE,TRUE,FALSE
-test,24,"[227, 233): 'League'",ORG,Wrong,"[211, 233): 'National Hockey League'",,15,,TRUE,FALSE,FALSE,FALSE
-test,24,"[211, 226): 'National Hockey'",ORG,Sentence,,,,,FALSE,FALSE,FALSE,TRUE
-test,25,"[1748, 1760): 'Philadelphia'",LOC,Tag,"[1748, 1760): 'Philadelphia'",ORG,,Philadelphia Eagles,TRUE,FALSE,TRUE,TRUE
-test,25,"[823, 835): 'Philadelphia'",LOC,Tag,"[823, 835): 'Philadelphia'",ORG,,Philadelphia Eagles,TRUE,TRUE,TRUE,TRUE
-test,26,"[1042, 1048): 'BOSTON'",LOC,Tag,"[1042, 1048): 'BOSTON'",ORG,,Boston basketball team,FALSE,FALSE,FALSE,TRUE
-test,26,"[1062, 1069): 'DETROIT'",LOC,Tag,"[1062, 1069): 'DETROIT'",ORG,17,basketball team,FALSE,TRUE,FALSE,FALSE
-test,26,"[1082, 1087): 'MIAMI'",LOC,Tag,"[1082, 1087): 'MIAMI'",ORG,17,bball team,FALSE,TRUE,FALSE,FALSE
-test,26,"[1099, 1109): 'SACRAMENTO'",LOC,Tag,"[1099, 1109): 'SACRAMENTO'",ORG,17,baskeball team,FALSE,TRUE,FALSE,FALSE
-test,26,"[1123, 1134): 'SAN ANTONIO'",LOC,Tag,"[1123, 1134): 'SAN ANTONIO'",ORG,,Basketball Team,FALSE,FALSE,FALSE,TRUE
-test,26,"[1148, 1152): 'UTAH'",LOC,Tag,"[1148, 1152): 'UTAH'",ORG,17,basketball team,FALSE,TRUE,FALSE,FALSE
-test,26,"[1166, 1174): 'PORTLAND'",LOC,Tag,"[1166, 1174): 'PORTLAND'",ORG,17,basketball team,FALSE,TRUE,FALSE,FALSE
-test,26,"[1186, 1198): 'GOLDEN STATE'",LOC,Tag,"[1186, 1198): 'GOLDEN STATE'",ORG,16,,FALSE,TRUE,FALSE,FALSE
-test,26,"[1210, 1219): 'LA LAKERS'",LOC,Tag,"[1210, 1219): 'LA LAKERS'",ORG,,Basketball Team,FALSE,FALSE,FALSE,TRUE
-test,26,"[94, 102): 'National'",ORG,Sentence,"[94, 125): 'National Basketball Association'",,17,,FALSE,TRUE,FALSE,FALSE
-test,26,"[236, 244): 'ATLANTIC'",LOC,Wrong,,,,Conferences/divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-test,26,"[822, 829): 'PACIFIC'",LOC,Wrong,,MISC,,Conferences/divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-test,26,"[94, 102): 'National'",,Wrong,,,,See next line,FALSE,FALSE,FALSE,TRUE
-test,27,"[1250, 1257): 'CHICAGO'",LOC,Tag,"[1250, 1257): 'CHICAGO'",ORG,,Football team,FALSE,FALSE,FALSE,TRUE
-test,27,"[1271, 1281): 'CINCINNATI'",LOC,Tag,"[1271, 1281): 'CINCINNATI'",ORG,,Football team,FALSE,FALSE,FALSE,TRUE
-test,27,"[1292, 1301): 'GREEN BAY'",LOC,Tag,"[1292, 1301): 'GREEN BAY'",ORG,,Football team,FALSE,FALSE,FALSE,TRUE
-test,27,"[1318, 1325): 'HOUSTON'",LOC,Tag,"[1318, 1325): 'HOUSTON'",ORG,17,football team,FALSE,TRUE,FALSE,FALSE
-test,27,"[1339, 1344): 'MIAMI'",LOC,Tag,"[1339, 1344): 'MIAMI'",ORG,17,football team,FALSE,TRUE,FALSE,FALSE
-test,27,"[1356, 1367): 'NEW ORLEANS'",LOC,Tag,"[1356, 1367): 'NEW ORLEANS'",ORG,,Football team,FALSE,FALSE,FALSE,TRUE
-test,27,"[1381, 1391): 'PITTSBURGH'",LOC,Tag,"[1381, 1391): 'PITTSBURGH'",ORG,,Football team,FALSE,FALSE,FALSE,TRUE
-test,27,"[1406, 1415): 'TAMPA BAY'",LOC,Tag,"[1406, 1415): 'TAMPA BAY'",ORG,16,,FALSE,TRUE,FALSE,FALSE
-test,27,"[1426, 1433): 'ARIZONA'",LOC,Tag,"[1426, 1433): 'ARIZONA'",ORG,17,football team,FALSE,TRUE,FALSE,FALSE
-test,27,"[1445, 1456): 'NEW ENGLAND'",LOC,Tag,"[1445, 1456): 'NEW ENGLAND'",ORG,,Football team,FALSE,FALSE,FALSE,TRUE
-test,27,"[1468, 1475): 'SEATTLE'",LOC,Tag,"[1468, 1475): 'SEATTLE'",ORG,17,football team,FALSE,TRUE,FALSE,FALSE
-test,27,"[1488, 1501): 'SAN FRANCISCO'",LOC,Tag,"[1488, 1501): 'SAN FRANCISCO'",ORG,,Football team,FALSE,FALSE,FALSE,TRUE
-test,27,"[1515, 1522): 'DETROIT'",LOC,Tag,"[1515, 1522): 'DETROIT'",ORG,,Football team,FALSE,FALSE,FALSE,TRUE
-test,27,"[1557, 1564): 'OAKLAND'",LOC,Tag,"[1557, 1564): 'OAKLAND'",ORG,,Football team,FALSE,FALSE,FALSE,TRUE
-test,27,"[208, 216): 'AMERICAN'",MISC,Both,"[208, 236): 'AMERICAN FOOTBALL CONFERENCE'",ORG,13,CHECK: I think this is a league and not a division ,FALSE,TRUE,FALSE,FALSE
-test,27,"[565, 573): 'X-DENVER'",MISC,Token,"[567, 573): 'DENVER'",ORG,16,"split on '-', X"" is an annotation""",TRUE,TRUE,FALSE,FALSE
-test,27,,,Token,"[567, 573): 'DENVER'",,10,"""X-"" prefix is a footnote, meaning ""CLINCHED DIVISION TITLE""",TRUE,FALSE,FALSE,FALSE
-test,27,"[889, 900): 'Y-GREEN BAY'",MISC,Token,"[891, 900): 'GREEN BAY'",ORG,16,"split on '-', Y"" is an annotation""",TRUE,TRUE,FALSE,FALSE
-test,27,"[410, 412): 'PA'",ORG,Wrong,,,14,Points Allowed,TRUE,TRUE,FALSE,FALSE
-test,28,"[82, 90): 'National'",ORG,Sentence,"[82, 106): 'National Football League'",,16,Also sentence boundary after National,TRUE,FALSE,FALSE,FALSE
-test,28,"[91, 99): 'Football'",LOC,Sentence,"[82, 106): 'National Football League'",ORG,16,,TRUE,FALSE,FALSE,FALSE
-test,28,"[91, 99): 'Football'",LOC,Sentence,"[82,106): 'National Football League'",ORG,17,,FALSE,TRUE,FALSE,FALSE
-test,28,"[82, 90): 'National'",ORG,Sentence,"[82,106): 'National Football League'",,17,,FALSE,TRUE,FALSE,FALSE
-test,28,"[91, 99): 'Football'",LOC,Wrong,,,,"""National Football League"" with sentence boundary and tag issues",FALSE,FALSE,FALSE,TRUE
-test,28,"[100, 106): 'League'",LOC,Wrong,,,,"""National Football League"" with sentence boundary and tag issues",FALSE,FALSE,FALSE,TRUE
-test,28,"[82, 90): 'National'",,Wrong,,,,See two lines down,FALSE,FALSE,FALSE,TRUE
-test,28,"[91, 99): 'Football'",,Wrong,,,,See next line,FALSE,FALSE,FALSE,TRUE
-test,29,"[220, 231): 'Rotary Club'",ORG,Span,"[220, 242): 'Rotary Club of Houston'",,,,FALSE,TRUE,FALSE,TRUE
-test,29,"[25, 44): 'FOOTBALL-OHIO STATE'",MISC,Token,"[34, 44): 'OHIO STATE'",ORG,16,"Need to split on '-' ""FOOTBALL-OHIO""",TRUE,FALSE,FALSE,FALSE
-test,29,"[25, 44): 'FOOTBALL-OHIO STATE'",MISC,Token,"[34,44): 'OHIO STATE'",ORG,17,,FALSE,TRUE,FALSE,FALSE
-test,29,"[235, 242): 'Houston'",LOC,Wrong,,,,,FALSE,TRUE,FALSE,TRUE
-test,31,"[561, 571): 'Schalke 04'",ORG,Span,"[561, 568): 'Schalke'",ORG,17,,FALSE,TRUE,FALSE,FALSE
-test,32,"[170, 177): 'Jocelyn'",PER,Sentence,"[170, 188): 'Jocelyn Gourvennec'",,17,,FALSE,TRUE,FALSE,FALSE
-test,33,,,Missing,"[151, 159): 'Starbuck'",PER,13,,TRUE,TRUE,FALSE,FALSE
-test,36,"[349, 358): 'Karlsruhe'",LOC,Tag,"[349, 358): 'Karlsruhe'",ORG,17,Soccer team,TRUE,TRUE,TRUE,FALSE
-test,36,"[385, 391): 'Dundee'",ORG,Tag,"[385, 391): 'Dundee'",PER,16,,TRUE,TRUE,TRUE,FALSE
-test,36,"[398, 406): 'Freiburg'",LOC,Tag,"[398, 406): 'Freiburg'",ORG,17,Soccer team,TRUE,TRUE,TRUE,FALSE
-test,38,"[43, 51): 'PORTUGAL'",LOC,Tag,"[43, 51): 'PORTUGAL'",ORG,17,Soccer team,FALSE,TRUE,FALSE,FALSE
-test,38,"[99, 104): 'Porto'",ORG,Tag,"[99, 104): 'Porto'",ORG,17,Soccer team,FALSE,TRUE,FALSE,FALSE
-test,39,"[1002, 1010): 'Gheorghe'",PER,Sentence,"[1002, 1018): 'Gheorghe Popescu'",,,Sentence boundary between first and last name,TRUE,TRUE,FALSE,TRUE
-test,39,"[1011, 1018): 'Popescu'",PER,Sentence,"[1002, 1018): 'Gheorghe Popescu'",PER,,Sentence boundary between first and last name,FALSE,FALSE,TRUE,TRUE
-test,39,"[1002, 1010): 'Gheorghe'",PER,Sentence,"[1002, 1018): 'Gheorghe popescu'",,17,,FALSE,TRUE,FALSE,FALSE
-test,39,"[1093, 1099): 'laPena'",PER,Sentence,"[1085, 1099): 'Ivan de la Pena'",,16,also token error on 'laPena' → 'la Pena',TRUE,FALSE,FALSE,FALSE
-test,39,"[1085, 1092): 'Ivan de'",PER,Sentence,"[1085, 1099): 'Ivan de laPena'",,17,,FALSE,TRUE,FALSE,FALSE
-test,39,"[1093, 1099): 'laPena'",PER,Sentence,"[1085, 1099): 'Ivan de laPena'",PER,,Sentence boundary between first and last name,FALSE,FALSE,TRUE,TRUE
-test,39,"[1121, 1125): 'Luis'",PER,Sentence,"[1121, 1133): 'Luis Enrique'",,17,,TRUE,TRUE,FALSE,FALSE
-test,39,"[1126, 1133): 'Enrique'",PER,Sentence,"[1121, 1133): 'Luis Enrique'",PER,,Sentence boundary between first and last name,FALSE,FALSE,TRUE,TRUE
-test,39,"[1158, 1175): 'AbelardoFernandez'",PER,Token,"[1158, 1175): 'Abelardo Fernandez'",PER,,"Missing space between ""Abelardo"" and ""Fernandez"".",FALSE,FALSE,FALSE,TRUE
-test,39,"[1243, 1249): 'Albert'",PER,Sentence,"[1243, 1256): 'Albert Ferrer'",,17,,TRUE,TRUE,FALSE,FALSE
-test,39,"[1250, 1256): 'Ferrer'",PER,Sentence,"[1243, 1256): 'Albert Ferrer'",PER,,Sentence boundary between first and last name,FALSE,FALSE,TRUE,TRUE
-test,39,"[925, 934): 'Guillermo'",PER,Sentence,"[925, 939): 'Guillermo Amor'",,17,,TRUE,TRUE,FALSE,FALSE
-test,39,"[935, 939): 'Amor'",PER,Sentence,"[925, 939): 'Guillermo Amor'",PER,,Sentence boundary between first and last name,FALSE,FALSE,TRUE,TRUE
-test,41,"[674, 682): 'Sporting'",ORG,Span,"[674, 688): 'Sporting Gijon'",ORG,17,,TRUE,TRUE,FALSE,FALSE
-test,42,"[19, 24): 'SPAIN'",LOC,Tag,"[19, 24): 'SPAIN'",ORG,17,Soccer team,FALSE,TRUE,FALSE,FALSE
-test,44,"[260, 268): 'Mercedes'",MISC,Tag,"[260, 268): 'Mercedes'",ORG,15,brand,FALSE,TRUE,FALSE,FALSE
-test,45,"[1361, 1366): 'Czech'",LOC,Tag,"[1361, 1366): 'Czech'",MISC,17,,FALSE,TRUE,FALSE,FALSE
-test,49,"[31, 39): 'S.AFRICA'",MISC,Tag,"[31, 39): 'S.AFRICA'",LOC,16,,TRUE,TRUE,FALSE,FALSE
-test,49,"[57, 63): 'DURBAN'",PER,Tag,"[57, 63): 'DURBAN'",LOC,16,city,TRUE,TRUE,TRUE,FALSE
-test,50,"[1262, 1267): 'Czech'",LOC,Tag,"[1262, 1267): 'Czech'",MISC,17,,FALSE,TRUE,FALSE,FALSE
-test,50,"[1838, 1843): 'Czech'",LOC,Tag,"[1838, 1843): 'Czech'",MISC,17,,FALSE,TRUE,FALSE,FALSE
-test,50,"[190, 195): 'Czech'",LOC,Tag,"[190, 195): 'Czech'",MISC,17,,FALSE,TRUE,FALSE,FALSE
-test,50,"[93, 98): 'Czech'",LOC,Tag,"[93, 98): 'Czech'",MISC,17,,FALSE,TRUE,FALSE,FALSE
-test,52,"[1006, 1011): 'Czech'",LOC,Tag,"[1006, 1011): 'Czech'",MISC,17,,FALSE,TRUE,FALSE,FALSE
-test,52,"[1400, 1405): 'Czech'",LOC,Tag,"[1400, 1405): 'Czech'",MISC,17,,FALSE,TRUE,FALSE,FALSE
-test,52,"[766, 771): 'Czech'",LOC,Tag,"[766, 771): 'Czech'",MISC,17,,FALSE,TRUE,FALSE,FALSE
-test,53,"[1020, 1024): 'Nazi'",MISC,Tag,"[1020, 1024): 'Nazi'",ORG,13,CHECK: revisit. Should these be combined? I lef them separate to minimize changes,FALSE,TRUE,FALSE,FALSE
-test,54,"[1145, 1152): 'Boxmeer'",PER,Token,"[1141, 1152): 'van Boxmeer'",,17,,FALSE,TRUE,FALSE,FALSE
-test,54,"[11, 27): 'INTERVIEW-ZYWIEC'",MISC,Token,"[21, 27): 'ZYWIEC'",ORG,17,,TRUE,TRUE,FALSE,FALSE
-test,54,"[2499, 2504): 'Czech'",LOC,Tag,"[2499, 2504): 'Czech'",MISC,17,,FALSE,TRUE,FALSE,FALSE
-test,54,"[2594, 2601): 'Boxmeer'",PER,Token,"[2590, 2601): 'van Boxmeer'",,17,,FALSE,TRUE,FALSE,FALSE
-test,54,"[2654, 2659): 'Czech'",LOC,Tag,"[2654, 2659): 'Czech'",MISC,17,,FALSE,TRUE,FALSE,FALSE
-test,54,"[2903, 2908): 'Czech'",LOC,Tag,"[2903, 2908): 'Czech'",MISC,17,,FALSE,TRUE,FALSE,FALSE
-test,54,"[3224, 3230): 'Zywiec'",ORG,Span,"[3224, 3241): 'Zywiec Full Light'",ORG,14,beer brand,TRUE,FALSE,FALSE,FALSE
-test,54,"[3421, 3428): 'Boxmeer'",PER,Token,"[3417, 3428): 'van Boxmeer'",,17,,FALSE,TRUE,FALSE,FALSE
-test,54,"[3421, 3428): 'Boxmeer'",,Span,"[3417, 3428): 'van Boxmeer'",PER,9,,TRUE,FALSE,FALSE,FALSE
-test,54,,,Token,"[?, 27): 'ZYWIEC'",ORG,,INTERVIEW-ZYWIECï¿½SEES NO BIG 97 NET RISE.,FALSE,TRUE,FALSE,TRUE
-test,54,"[3231, 3241): 'Full Light'",MISC,Wrong,,,16,"See previous line – type of beer, brand",TRUE,FALSE,FALSE,FALSE
-test,55,"[129, 134): 'Czech'",LOC,Tag,"[129, 134): 'Czech'",MISC,17,,FALSE,TRUE,FALSE,FALSE
-test,56,"[11, 16): 'UK-US'",MISC,Token,"[11, 13): 'UK'",LOC,15,,FALSE,TRUE,FALSE,FALSE
-test,56,"[11, 16): 'UK-US'",MISC,Token,"[14, 16): 'US'",LOC,,,FALSE,FALSE,FALSE,TRUE
-test,61,,,Missing,"[11, 14): 'Med'",MISC,,"Abbreviation for ""Mediterranean""",FALSE,FALSE,FALSE,TRUE
-test,61,,,Missing,"[1550, 1553): 'Med'",MISC,,"Short for ""Mediterranean""",FALSE,TRUE,TRUE,TRUE
-test,61,"[395, 400): 'Genoa'",ORG,Tag,"[395, 400): 'Genoa'",LOC,17,,FALSE,TRUE,FALSE,FALSE
-test,61,,,Missing,"[79, 92): 'Mediterranean'",MISC,13,,TRUE,TRUE,FALSE,FALSE
-test,61,,,Missing,"[898, 901): 'Med'",MISC,8,"Abbreviation for ""Mediterranean""",TRUE,FALSE,FALSE,FALSE
-test,63,"[148, 160): 'Conservative'",MISC,Tag,"[148, 160): 'Conservative'",ORG,16,political party,TRUE,FALSE,FALSE,FALSE
-test,63,"[19, 39): 'office-Conservatives'",MISC,Token,"[26, 39): 'Conservatives'  ",ORG,14,political party,TRUE,FALSE,FALSE,FALSE
-test,63,"[19, 39): 'office-Conservatives'",MISC,Token,"[27, 39): 'Conservatives'",ORG,14,conservative party,FALSE,TRUE,FALSE,FALSE
-test,67,"[682, 690): 'Manitoba'",ORG,Tag,"[682, 690): 'Manitoba'",MISC,8,"""Manitoba Government Price Index""",TRUE,FALSE,FALSE,FALSE
-test,68,"[11, 19): 'Canadian'",MISC,Span,"[11, 30): 'Canadian West Coast'",LOC,17,"Ambiguous: Could be two entities (""Canadian"" and ""West Coast"")",FALSE,TRUE,FALSE,FALSE
-test,68,"[157, 165): 'Canadian'",MISC,Span,"[157, 176): 'Canadian West Coast'",LOC,17,"Ambiguous: Could be two entities (""Canadian"" and ""West Coast"")",FALSE,TRUE,FALSE,FALSE
-test,68,,,Missing,"[166, 176): 'West Coast'",LOC,,"Corpus *does* flag ""Canadian"" as MISC",TRUE,TRUE,FALSE,TRUE
-test,68,,,Missing,"[20, 30): ' West Coast'",LOC,,abstract ``places'' (e.g. {\it the free world}),FALSE,FALSE,FALSE,TRUE
-test,68,,,Missing,"[224, 234): 'West Coast'",LOC,,,TRUE,TRUE,TRUE,TRUE
-test,68,,,Missing,"[335, 345): 'East Coast'",LOC,,,TRUE,TRUE,TRUE,TRUE
-test,68,,,Missing,"[48, 51): 'CWB'",ORG,12,Canadian Wheat Board,TRUE,FALSE,FALSE,FALSE
-test,70,"[177, 197): 'New York Commodities'",ORG,Span,"[177, 202): 'New York Commodities Desk'",ORG,17,,TRUE,TRUE,FALSE,FALSE
-test,71,"[153, 173): 'New York Commodities'",ORG,Span,"[153, 178): 'New York Commodities Desk'",ORG,17,,TRUE,TRUE,FALSE,FALSE
-test,71,,,Missing,"[89, 107): 'WESTERN HEMISPHERE'",LOC,10,Example in training set of exactly the same entity tagged LOC,TRUE,FALSE,TRUE,FALSE
-test,72,"[154, 167): 'MEDITERRANEAN'",MISC,Tag,"[154, 167): 'MEDITERRANEAN'",LOC,17,Mediterannian = shortening of mediteranian ocean,FALSE,TRUE,FALSE,FALSE
-test,72,"[288, 294): 'Bajaia'",LOC,Tag,"[288, 294): 'Bajaia'",ORG,17,company? ,FALSE,TRUE,FALSE,FALSE
-test,72,,,Missing,"[78, 85): 'MIDEAST'",LOC,14,,TRUE,FALSE,TRUE,FALSE
-test,73,"[11, 14): 'NYC'",MISC,Tag,"[11, 14): 'NYC'",LOC,16,,FALSE,TRUE,FALSE,FALSE
-test,75,"[1438, 1444): 'Busang'",ORG,Tag,"[1438, 1444): 'Busang'",LOC,17,Location of ore deposit. We need to check elsewhere that this is labelled correctly ,FALSE,TRUE,FALSE,FALSE
-test,75,"[1438, 1444): 'Busang'",ORG,Span,"[1438, 1444): 'Busang'",,,Indonesia'sÊBusangÊvast gold deposit,FALSE,FALSE,TRUE,TRUE
-test,75,"[2736, 2752): 'Newmont-Santa Fe'",MISC,Token,"[2736, 2743): 'Newmont'",ORG,,Token error between two companies in a deal,FALSE,FALSE,FALSE,TRUE
-test,75,"[2736, 2752): 'Newmont-Santa Fe'",MISC,Token,"[2744, 2752): 'Santa Fe'",ORG,15,Token error between two companies in a deal,FALSE,TRUE,FALSE,FALSE
-test,75,"[2890, 2898): 'Santa Fe'",LOC,Tag,"[2890, 2898): 'Santa Fe'",ORG,17,,TRUE,TRUE,TRUE,FALSE
-test,75,"[36, 44): 'Santa Fe'",LOC,Tag,"[36, 44): 'Santa Fe'",ORG,17,Santa fe mining co.,TRUE,TRUE,TRUE,FALSE
-test,78,,,Missing,"[3425, 3431): 'Masisi'",LOC,,,TRUE,TRUE,TRUE,TRUE
-test,82,"[1178, 1184): 'Yakoma'",MISC,Tag,"[1178, 1184): 'Yakoma'",ORG,15,Tribe name ,FALSE,TRUE,FALSE,FALSE
-test,87,,,Missing,"[148, 159): 'Polish-born'",MISC,,,FALSE,TRUE,TRUE,TRUE
-test,88,,,Missing,"[1628, 1637): 'Far North'",LOC,,,TRUE,TRUE,TRUE,TRUE
-test,90,"[1129, 1140): 'Warsaw Pact'",MISC,Tag,"[1129, 1140): 'Warsaw Pact'",ORG,17,,FALSE,TRUE,FALSE,FALSE
-test,93,,,Missing,"[502, 509): 'Ottoman'",MISC,,"Treat ""Ottoman"" and ""Turkish"" as two separate MISC entities",FALSE,FALSE,TRUE,TRUE
-test,93,"[510, 517): 'Turkish' 	",,Span,"[502, 517): 'Ottoman Turkish'",MISC,,"""Ottoman turkey"" is an entity ",FALSE,TRUE,FALSE,TRUE
-test,94,"[331, 339): 'Budapest'",LOC,Span,"[331, 339): 'Budapest Bank’s'",ORG,14,bank name,TRUE,FALSE,FALSE,FALSE
-test,94,"[331, 339): 'Budapest'",LOC,Both,"[331, 344): 'Budapest Bank'",ORG,17,,FALSE,TRUE,FALSE,FALSE
-test,95,"[1656, 1665): 'Santander'",LOC,Tag,"[1656, 1665): 'Santander'",ORG,,,FALSE,TRUE,TRUE,TRUE
-test,100,"[56, 64): 'SANTIAGO'",PER,Tag,"[56, 64): 'SANTIAGO'",LOC,,,TRUE,TRUE,TRUE,TRUE
-test,100,"[941, 948): 'Chilean'",MISC,Both,"[941, 957): 'Chilean Congress'",ORG,10,,TRUE,FALSE,FALSE,FALSE
-test,100,,,Missing,"[949, 957): 'Congress'",ORG,,,FALSE,TRUE,TRUE,TRUE
-test,100,,,Missing,"[987, 995): 'Congress'",ORG,,,TRUE,TRUE,TRUE,TRUE
-test,103,"[193, 220): 'Ranyon (Rangoon) University'",ORG,Tag,"[193, 220): 'Ranyon (Rangoon) University'",LOC,15,,TRUE,FALSE,FALSE,FALSE
-test,103,"[794, 812): 'Rangoon University'",ORG,Tag,"[794, 812): 'Rangoon University'",LOC,,,FALSE,FALSE,FALSE,TRUE
-test,105,,,Missing,"[740, 748): 'Hansenne'",PER,,,TRUE,TRUE,TRUE,TRUE
-test,108,"[1510, 1527): 'Christian-Shi'ite'",MISC,Span,"[1510, 1534): 'Christian-Shi'ite Moslem'",MISC,15,all describes one force of people,TRUE,FALSE,FALSE,FALSE
-test,108,"[59, 75): 'Haitham Haddadin'",ORG,Tag,"[59, 75): 'Haitham Haddadin'",PER,17,,TRUE,TRUE,TRUE,FALSE
-test,108,"[1528, 1534): 'Moslem'",Misc,Wrong,,,,,FALSE,FALSE,FALSE,TRUE
-test,112,"[1560, 1581): 'U.S. Court of Appeals'",ORG,Span,"[1547, 1581): '11th Circuit U.S. Court of Appeals'",,,,FALSE,FALSE,TRUE,TRUE
-test,112,"[174, 184): 'John Mills'",PER,Span,"[174, 187): 'John Mills Jr'",PER,16,,TRUE,FALSE,FALSE,FALSE
-test,112,"[174, 184): 'John Mills'",,Span,"[174, 187): 'John Mills Jr'",,16,,TRUE,TRUE,FALSE,FALSE
-test,114,"[11, 17): 'Iowa-S'",LOC,Token,"[11, 15): 'Iowa'",LOC,,"""Iowa-S"" treated as a single token",FALSE,FALSE,FALSE,TRUE
-test,114,"[11, 17): 'Iowa-S'",LOC,Token,"[11, 15): 'Iowa'  ",,14,split on ‘-’,TRUE,FALSE,FALSE,FALSE
-test,114,"[18, 22): 'Minn'",LOC,Span,"[16, 22): 'S Minn'",,,,FALSE,FALSE,FALSE,TRUE
-test,114,"[51, 61): 'sales-USDA'",MISC,Token,"[57, 61): 'USDA'",MISC,17,,FALSE,TRUE,FALSE,FALSE
-test,115,,,Missing,"[459, 465): 'Luebke'",PER,,,TRUE,TRUE,TRUE,TRUE
-test,117,,,Missing,"[1270, 1273): 'Hub'",LOC,8,Henry Hub,TRUE,FALSE,FALSE,FALSE
-test,117,,,Missing,"[2227, 2236): 'Southwest'",LOC,,,TRUE,TRUE,TRUE,TRUE
-test,118,"[127, 136): 'St. Louis'",LOC,Both,"[127, 155): 'St. Louis Merchants Exchange'",ORG,17,"Ambiguous: Location, but also a company I think? ",FALSE,TRUE,FALSE,FALSE
-test,118,"[127, 136): 'St. Louis'",LOC,Span,"[127, 155): 'St. Louis Merchants Exchange'",ORG ,,"A building in St. Louis. However it is also a company, and I believe that in this case it is the company being referred to ",FALSE,TRUE,FALSE,TRUE
-test,118,"[535, 550): 'mid-Mississippi'",MISC,Tag,"[535, 550): 'mid-Mississippi'",LOC,17,,TRUE,TRUE,FALSE,FALSE
-test,118,"[552, 560): 'McGregor'",PER,Tag,"[552, 560): 'McGregor'",LOC,17,,FALSE,TRUE,FALSE,FALSE
-test,118,"[552, 560): 'McGregor'  ",PER,Tag,"[552, 560): 'McGregor'  ",LOC,,is a city on the Mississippi River,FALSE,FALSE,FALSE,TRUE
-test,118,"[776, 791): 'mid-Mississippi'",MISC,Tag,"[776, 791): 'mid-Mississippi'",LOC,17,,FALSE,TRUE,FALSE,FALSE
-test,118,"[776, 791): 'mid-Mississippi'  ",MISC,Tag,"[776, 791): 'mid-Mississippi'  ",LOC,,location where barge is,FALSE,FALSE,FALSE,TRUE
-test,121,,,Missing,"[11, 29): 'Action Performance'",ORG,,,FALSE,TRUE,FALSE,TRUE
-test,122,"[273, 286): 'United States'",LOC,Both,"[251, 286): 'Human Society of the United States'",ORG,8,,TRUE,FALSE,FALSE,FALSE
-test,122,"[522, 545): 'Glencoe Animal Hospital'",ORG,Tag,"[522, 545): 'Glencoe Animal Hospital'",LOC,15,specific hospitol,TRUE,FALSE,FALSE,FALSE
-test,123,"[11, 17): 'Iowa-S'",LOC,Token,"[11, 15): 'Iowa'  ",,15,split on '-',TRUE,FALSE,FALSE,FALSE
-test,123,"[18, 22): 'Minn'",LOC,Span,"[16, 22): 'S Minn'",,,,FALSE,FALSE,FALSE,TRUE
-test,127,"[528, 531): 'RAI'",LOC,Tag,"[528, 531): 'RAI'",ORG,17,,FALSE,TRUE,FALSE,FALSE
-test,130,"[389, 395): 'Europe'",LOC,Both,"[389, 405): 'Europe Agreement'",MISC,17,,FALSE,TRUE,FALSE,FALSE
-test,131,,,Missing,"[449, 454): 'Babri'",LOC,,the Babri mosque,TRUE,FALSE,TRUE,TRUE
-test,131,,,Missing,"[449, 461): 'Babri mosque'",LOC,,https://en.wikipedia.org/wiki/Babri_Masjid,FALSE,TRUE,FALSE,TRUE
-test,134,"[62, 73): 'Lantau Peak'",MISC,Tag,"[62, 73): 'Lantau Peak'",LOC,15,??? def a peak,TRUE,FALSE,FALSE,FALSE
-test,136,"[647, 657): 'Treasuries'",MISC,Wrong,,,16,"??? ""Returns on Treasuries"".. talking about investments but is capitolized",TRUE,FALSE,FALSE,FALSE
-test,137,"[313, 324): 'Bonny Light'",MISC,Tag,"[313, 324): 'Bonny Light'",ORG,16,brand? ,FALSE,TRUE,FALSE,FALSE
-test,137,"[341, 354): 'Arabian Light'",MISC,Tag,"[341, 354): 'Arabian Light'",ORG,16,Brand? ,FALSE,TRUE,FALSE,FALSE
-test,140,,,Missing,"[1565, 1581): 'Arafat-Netanyahu'",MISC,,"It's an adjective used to describe the relation/time period between 2 people, hence the tag is MISC",TRUE,TRUE,TRUE,TRUE
-test,142,"[342, 348): 'Kesers'",PER,Tag,"[342, 348): 'Kesers'",MISC,17,Two rival clans ,FALSE,TRUE,FALSE,FALSE
-test,142,"[353, 363): 'Karabuluts'",PER,Tag,"[353, 363): 'Karabuluts'",ORG,14,Clan name ,FALSE,TRUE,FALSE,FALSE
-test,146,"[11, 17): 'ACCESS'",MISC,Tag,"[11, 17): 'ACCESS'",ORG,17,Short fo NYMEX ACCESS,FALSE,TRUE,FALSE,FALSE
-test,146,"[143, 155): 'NYMEX ACCESS'",MISC,Tag,"[143, 155): 'NYMEX ACCESS'",ORG,17,Stock market ,FALSE,TRUE,FALSE,FALSE
-test,146,"[62, 73): 'LOS ANGELES'",ORG,Tag,"[62, 73): 'LOS ANGELES'",LOC,8,,TRUE,FALSE,FALSE,FALSE
-test,146,"[632, 638): 'ACCESS'",MISC,Tag,"[632, 638): 'ACCESS'",ORG,17,Short fo NYMEX ACCESS,FALSE,TRUE,FALSE,FALSE
-test,148,"[314, 335): 'St Pius X High School'",ORG,Tag,"[314, 335): 'St Pius X High School'",LOC,14,specific high school in abq,TRUE,FALSE,FALSE,FALSE
-test,149,"[1504, 1520): 'Consumer Project'",PER,Both,"[1504, 1534): 'Consumer Project on Technology'",ORG,17,,TRUE,TRUE,TRUE,FALSE
-test,149,,,Missing,"[2650, 2653): 'Net'",MISC,,"Capitalized and short for ""Internet"", which is tagged MISC throughout this document",FALSE,FALSE,FALSE,TRUE
-test,149,,,Missing,"[902, 909): 'Western'",MISC,,,TRUE,TRUE,TRUE,TRUE
-test,149,"[2894, 2902): 'Internet'",MISC,Wrong,,,16,,FALSE,TRUE,FALSE,FALSE
-test,149,"[2233, 2241): 'Internet'",MISC,Wrong,,,16,,FALSE,TRUE,FALSE,FALSE
-test,149,"[3687, 3694): 'Network'",MISC,Wrong,,,14,“Network operators…” ref to internet?,TRUE,FALSE,FALSE,FALSE
-test,149,"[3340, 3348): 'Internet'",MISC,Wrong,,,14,,FALSE,TRUE,FALSE,FALSE
-test,149,"[1100, 1108): 'Internet'",MISC,Wrong,,,14,,FALSE,TRUE,FALSE,FALSE
-test,149,"[155, 163): 'Internet'",MISC,Wrong,,,,,FALSE,FALSE,FALSE,TRUE
-test,149,"[2448, 2456): 'Internet'",MISC,Wrong,,,,,FALSE,FALSE,FALSE,TRUE
-test,149,"[3905, 3913): 'Internet'",MISC,Wrong,,,,,FALSE,FALSE,FALSE,TRUE
-test,149,"[3516, 3524): 'Internet'",MISC,Wrong,,,,,FALSE,FALSE,FALSE,TRUE
-test,149,"[3240, 3248): 'Internet'",MISC,Wrong,,,,,FALSE,FALSE,FALSE,TRUE
-test,152,"[1035, 1041): 'League'",LOC,Tag,"[1035, 1041): 'League'",ORG,17,Zach: short for a political group; Fred: Northern League,TRUE,TRUE,FALSE,FALSE
-test,152,"[1487, 1489): 'Po'",LOC,Span,"[1487, 1495): 'Po River'",LOC,16,,TRUE,FALSE,FALSE,FALSE
-test,152,,,Missing,"[321, 327): 'Mantua'",LOC,,,TRUE,TRUE,TRUE,TRUE
-test,152,,,Missing,"[61, 67): 'MANTUA'",LOC,,,TRUE,TRUE,TRUE,TRUE
-test,152,"[556, 559): 'Let'",LOC,Wrong,,,17,,TRUE,TRUE,FALSE,FALSE
-test,153,,,Missing,"[21, 31): 'Radiometer'",ORG,,,TRUE,TRUE,TRUE,TRUE
-test,153,"[229, 238): 'Wednesday'",ORG,Wrong,,,17,,TRUE,TRUE,FALSE,FALSE
-test,155,"[423, 430): 'Antwerp'",ORG,Tag,"[423, 430): 'Antwerp'",LOC,17,,TRUE,TRUE,TRUE,FALSE
-test,155,"[776, 783): 'Antwerp'",ORG,Tag,"[776, 783): 'Antwerp'",LOC,17,,TRUE,TRUE,TRUE,FALSE
-test,158,"[69, 79): 'Muenchener'",MISC,Tag,"[69, 101): 'Muenchener Rueckversicherungs AG'",ORG,17,,FALSE,TRUE,FALSE,FALSE
-test,158,"[80, 101): 'Rueckversicherungs AG'  ",ORG,Span,"[69, 101): 'Muenchener Rueckversicherungs AG'",,,insurance company,FALSE,FALSE,FALSE,TRUE
-test,158,"[69, 79): 'Muenchener'",MISC,Wrong,,,16,,TRUE,FALSE,FALSE,FALSE
-test,161,"[11, 24): 'John Lewis UK'",ORG,Span,"[11, 21): 'John Lewis UK'",ORG,,,FALSE,FALSE,FALSE,TRUE
-test,161,"[11, 24): 'John Lewis UK'",ORG,Span,"[11, 21): 'John Lewis'",ORG,15,"??? division of company based in UK, should UK be separate?",TRUE,FALSE,FALSE,FALSE
-test,161,"[11, 24): 'John Lewis UK'",ORG,Both,"[22, 24): 'UK'",LOC,,,FALSE,FALSE,FALSE,TRUE
-test,161,"[76, 86): 'John Lewis'",PER,Tag,"[76, 86): 'John Lewis'",ORG,17,company with name John Lewis ,FALSE,TRUE,FALSE,FALSE
-test,161,"[76, 86): 'John Lewis'",PER,Both,"[76, 98): 'John Lewis Partnership'",ORG,,,FALSE,TRUE,TRUE,TRUE
-test,163,"[121, 133): 'Conservative'",MISC,Tag,"[121, 133): 'Conservative'",ORG,15,political party,TRUE,FALSE,FALSE,FALSE
-test,163,,,Missing,"[411, 424): 'Conservatives'",MISC,,,FALSE,FALSE,TRUE,TRUE
-test,166,"[41, 43): 'NZ'",LOC,Both,"[41, 49): 'NZ First'",ORG,,,TRUE,TRUE,TRUE,TRUE
-test,167,"[28, 31): 'Nat'",PER,Tag,"[28, 31): 'Nat'",ORG,7,New Zealand National Party,TRUE,FALSE,FALSE,FALSE
-test,167,"[33, 36): 'Lab'",PER,Tag,"[33, 36): 'Lab'",ORG,,New Zealand Labour Party,FALSE,FALSE,FALSE,TRUE
-test,168,,,Missing,"[1023, 1028): 'Labor'",ORG,,Reference to Australian Labor Party,FALSE,TRUE,TRUE,TRUE
-test,168,"[1040, 1046): 'Fraser'",PER,Tag,"[1040, 1046): 'Fraser'",LOC,17,Electoral Reigon ,FALSE,TRUE,FALSE,FALSE
-test,168,"[1346, 1354): 'Canberra'",LOC,Both,"[1346, 1361): 'Canberra Bureau'",ORG,,"""Bureau"" is capitalized",TRUE,TRUE,TRUE,TRUE
-test,168,"[429, 435): 'Fraser'",PER,Tag,"[429, 435): 'Fraser'",LOC,17,Electoral Reigon ,FALSE,TRUE,FALSE,FALSE
-test,168,"[443, 471): 'Australian Capital Territory'",MISC,Tag,"[443, 471): 'Australian Capital Territory'",LOC,17,Reigon ,TRUE,TRUE,TRUE,FALSE
-test,170,"[321, 329): 'Seagramd'",MISC,Span,"[321, 333): 'Seagramd ace'",MISC,14,"full vessel name, Ace should prob be cap",TRUE,FALSE,FALSE,FALSE
-test,170,"[627, 634): 'Bangkok'",MISC,Tag,"[627, 634): 'Bangkok'",LOC,17,,FALSE,TRUE,FALSE,FALSE
-test,173,,,Missing,"[278, 289): 'Port Office'",ORG,,,TRUE,TRUE,TRUE,TRUE
-test,176,,,Missing,"[2024, 2032): 'Ministry'",ORG,12,,TRUE,FALSE,FALSE,FALSE
-test,176,,,Missing,"[2276, 2284): 'Ministry'",ORG,11,"Reference to the Indonesian Mines and Energy Ministry. Single-word, but capitalized ""M""",TRUE,FALSE,FALSE,FALSE
-test,176,"[2419, 2425): 'Busang'",ORG,Tag,"[2419, 2425): 'Busang'",LOC,17,Location of gold mine ,FALSE,TRUE,FALSE,FALSE
-test,176,"[2732, 2738): 'Busang'",ORG,Tag,"[2732, 2738): 'Busang'",LOC,17,Location of gold mine ,FALSE,TRUE,FALSE,FALSE
-test,176,"[2779, 2794): 'PT Panutan Duta'",PER,Tag,"[2779, 2794): 'PT Panutan Duta'",ORG,17,,TRUE,TRUE,TRUE,FALSE
-test,176,"[2887, 2894): 'Panutan'",PER,Tag,"[2887, 2894): 'Panutan'",ORG,16,,FALSE,TRUE,FALSE,FALSE
-test,176,"[2960, 2966): 'Busang'",ORG,Tag,"[2960, 2966): 'Busang'",LOC,15,,TRUE,FALSE,FALSE,FALSE
-test,176,"[57, 67): 'K.T. Arasu'",LOC,Tag,"[57, 67): 'K.T. Arasu'",PER,17,,TRUE,TRUE,FALSE,FALSE
-test,177,"[11, 19): 'Honda RV'",MISC,Span,"[11, 16): 'Honda'",,,,FALSE,FALSE,TRUE,TRUE
-test,177,"[11, 19): 'Honda RV'",MISC,Both,"[11, 16): 'Honda'",ORG,9,"Article is about a single type of RV made by Honda Motor Co. ""RV"" is a generic term in this context. ""Honda"" used as an adjective",TRUE,FALSE,FALSE,FALSE
-test,178,"[1787, 1794): 'Uruguay'",LOC,Both,"[1787, 1800): 'Uruguay Round'",MISC,17,"Zach: Ambiguous; Fred: I think the Uruguay Round qualifies as an ""event"" and should be tagged MISC; see https://en.wikipedia.org/wiki/Uruguay_Round",FALSE,TRUE,FALSE,FALSE
-test,178,,,Missing,"[2272, 2276): 'West'",LOC,13,"""the West""",TRUE,FALSE,FALSE,FALSE
-test,178,"[951, 960): 'then-U.S.'",MISC,Token,"[956, 960): 'U.S.'",LOC,17,,FALSE,TRUE,FALSE,FALSE
-test,179,,,Missing,"[594, 622): 'Posts and Telecommunications'",ORG,,Japanese government ministry,FALSE,TRUE,TRUE,TRUE
-test,180,"[216, 220): 'BILO'",MISC,Tag,"[216, 220): 'BILO'",ORG,15,??? chain of discount stores,TRUE,TRUE,FALSE,FALSE
-test,180,"[259, 263): 'BILO'",MISC,Tag,"[259, 263): 'BILO'",ORG,17,A store chain ,TRUE,TRUE,FALSE,FALSE
-test,180,"[395, 399): 'BILO'",MISC,Tag,"[395, 399): 'BILO'",ORG,17,Store chain ,TRUE,TRUE,FALSE,FALSE
-test,180,"[450, 454): 'TOPS'",MISC,Tag,"[450, 454): 'TOPS'",ORG,17,Brand,TRUE,TRUE,FALSE,FALSE
-test,180,"[579, 583): 'TOPS'",MISC,Tag,"[579, 583): 'TOPS'",ORG,16,,TRUE,TRUE,FALSE,FALSE
-test,180,"[588, 592): 'BILO'",MISC,Tag,"[588, 592): 'BILO'",ORG,17,Brand,TRUE,TRUE,FALSE,FALSE
-test,183,"[18, 35): 'SKIING-GLADISHIVA'",MISC,Token,"[25, 35): 'GLADISHIVA'",PER,17,,TRUE,TRUE,TRUE,FALSE
-test,184,"[394, 398): 'LPGA'",ORG,Both,"[394, 404): 'LPGA Tours'",MISC,8,,TRUE,FALSE,FALSE,FALSE
-test,184,"[633, 637): 'U.S.'",LOC,Both,"[633, 645): 'U.S. Amateur'",MISC,,United States Amateur Championship,FALSE,TRUE,FALSE,TRUE
-test,186,"[1275, 1283): 'Florence'",LOC,Both,"[1275, 1291): 'Florence Masnada'",PER,,,FALSE,TRUE,FALSE,TRUE
-test,186,"[1284, 1291): 'Masnada'",PER,Wrong,"[1275, 1291): 'Florence Masnada'",,17,Combined with above,FALSE,TRUE,FALSE,FALSE
-test,186,"[1284, 1291): 'Masnada'",PER,Span,"[1275, 1291): 'Florence Masnada'  ",PER,16,,TRUE,FALSE,FALSE,FALSE
-test,186,,,Token,"[1398, 1405): 'Austria'",LOC,,Tokenizer treated 'Austria)118' as a single token,FALSE,FALSE,TRUE,TRUE
-test,186,"[432, 446): 'Ingeborg Helen'",PER,Span,"[432, 454): 'Ingeborg Helen Markein'",PER,17,,TRUE,TRUE,FALSE,FALSE
-test,186,"[432, 446): 'Ingeborg Helen'",,Span,"[432, 454): 'Ingeborg Helen Markein'",,15,,TRUE,TRUE,FALSE,FALSE
-test,186,"[533, 541): 'Florence'",LOC,Both,"[533, 549): 'Florence Masnada'",PER,,,FALSE,TRUE,FALSE,TRUE
-test,186,"[542, 549): 'Masnada'",PER,Wrong,"[533, 549): 'Florence Masnada'",,17,Combined with above,FALSE,TRUE,FALSE,FALSE
-test,186,"[542, 549): 'Masnada'",PER,Span,"[533, 549): 'Florence Masnada'  ",PER,16,,TRUE,FALSE,FALSE,FALSE
-test,186,"[1275, 1283): 'Florence'",LOC,Wrong,,,,,FALSE,FALSE,TRUE,TRUE
-test,186,"[533, 541): 'Florence'",LOC,Wrong,,,,,FALSE,FALSE,TRUE,TRUE
-test,186,"[1607, 1614): 'Super G'",MISC,Wrong,,,17,"Fred: Short for ""super giant slalom"", which is a generic term for an event; also, the ""super g"" is mentioned elsewhere in the same doc and not tagged there",FALSE,TRUE,FALSE,FALSE
-test,186,"[533, 541): 'Florence'  ",LOC,Wrong,,,,,FALSE,FALSE,FALSE,TRUE
-test,187,"[1173, 1179): 'Germay'",,Missing,"[1173, 1179): 'Germay'",LOC ,,Misspelling of Germany,FALSE,TRUE,FALSE,TRUE
-test,187,,,Missing,"[1173, 1179): 'Germay'",LOC,11,,TRUE,FALSE,FALSE,FALSE
-test,188,"[18, 34): 'SKIING-WORLD CUP'",MISC,Token,"[25, 34): 'WORLD CUP'",,17,,FALSE,TRUE,FALSE,FALSE
-test,190,"[11, 27): 'BOBSLEIGH-SHIMER'",MISC,Token,"[21, 27): 'SHIMER'",PER,16,,FALSE,TRUE,FALSE,FALSE
-test,190,"[440, 445): 'Italy'",LOC,Both,"[440, 447): 'Italy I'",ORG,16,THIS IS A REPEAT WHATS HAPPENING ,FALSE,TRUE,FALSE,FALSE
-test,190,"[440, 445): 'Italy'  ",LOC,Span,"[440, 447): 'Italy I'  ",ORG,,bobsled division,FALSE,FALSE,FALSE,TRUE
-test,190,"[11, 27): 'BOBSLEIGH-SHIMER'",MISC,Token,,,16,,TRUE,FALSE,FALSE,FALSE
-test,191,"[11, 25): 'SKIING-CHINESE'",MISC,Token,"[18, 25): 'CHINESE'",ORG,17,,FALSE,TRUE,FALSE,FALSE
-test,192,"[11, 30): 'BOBSLEIGH-WORLD CUP'",MISC,Token,"[21, 30): 'WORLD CUP'",,17,,FALSE,TRUE,FALSE,FALSE
-test,192,"[808, 815): 'Garrett'",PER,Sentence,"[808, 821): 'Garrett Hines'",PER,,Sentence boundary between first and last name,FALSE,TRUE,TRUE,TRUE
-test,193,"[744, 759): 'United Province'",LOC,Tag,"[744, 759): 'United Province'",ORG,17,"Fred: Somewhat ambiguous, but appears to refer to the United Province cricket team",FALSE,TRUE,FALSE,FALSE
-test,194,"[21, 37): 'SKIING-WORLD CUP'",MISC,Token,"[28, 37): 'WORLD CUP'",,16,,FALSE,TRUE,FALSE,FALSE
-test,195,"[21, 37): 'SKIING-WORLD CUP'",MISC,Token,"[28, 37): 'WORLD CUP'",MISC,,"Tokenizer treated ""SKIING-WORLD"" as a single token",FALSE,FALSE,TRUE,TRUE
-test,199,"[108, 124): 'Scottish premier'",MISC,Span,"[108, 116): 'Scottish'",MISC,,Divisions of leagues not considered entities,TRUE,TRUE,TRUE,TRUE
-test,199,"[108, 124): 'Scottish premier'",,Span,"[108, 116): 'Scottish'",,16,"Ambiguous: Divisions of leagues not entities, but ""Scottish premier"" could be seen as a term derived from a location",TRUE,FALSE,FALSE,FALSE
-test,199,"[108, 124): 'Scottish premier'",MISC,Span,"[108, 133): 'Scottish premier division'",MISC,17,,FALSE,TRUE,FALSE,FALSE
-test,199,"[27, 52): 'SCOTTISH PREMIER DIVISION'",MISC,Span,"[27, 35): 'SCOTTISH'",MISC,16,,TRUE,FALSE,FALSE,FALSE
-test,199,"[491, 498): 'Winters'",PER,Sentence,"[484, 498): 'Robert Winters'",PER,,Sentence boundary between first and last names,FALSE,TRUE,TRUE,TRUE
-test,199,"[484, 490): 'Robert'",PER,Sentence,"[484, 498): 'Robert Winters'",,17,,FALSE,TRUE,FALSE,FALSE
-test,200,"[288, 293): 'Villa'",ORG,Sentence,"[282, 293): 'Aston Villa'",ORG,,Sentence boundary between first and last names,TRUE,TRUE,TRUE,TRUE
-test,200,"[282, 287): 'Aston'",ORG,Sentence,"[282, 293): 'Aston Villa'",,17,,FALSE,TRUE,FALSE,FALSE
-test,200,"[335, 344): 'Wimbledon'",LOC,Tag,"[335, 344): 'Wimbledon'",ORG,,Soccer team,FALSE,TRUE,TRUE,TRUE
-test,200,"[390, 399): 'Wimbledon'",LOC,Tag,"[390, 399): 'Wimbledon'",ORG,,Soccer team,FALSE,TRUE,TRUE,TRUE
-test,200,"[445, 454): 'Wimbledon'",LOC,Tag,"[445, 454): 'Wimbledon'",ORG,,Soccer team,FALSE,TRUE,TRUE,TRUE
-test,200,"[479, 484): 'Chris'",PER,Sentence,"[479, 491): 'Chris Sutton'",PER,,Sentence boundary between first and last names,FALSE,TRUE,TRUE,TRUE
-test,202,,,Missing,"[24, 31): 'BRITISH'",MISC,16,,TRUE,TRUE,TRUE,FALSE
-test,202,"[11, 22): 'RUGBY UNION'",ORG,Wrong,,,,https://en.wikipedia.org/wiki/Rugby_union,FALSE,FALSE,FALSE,TRUE
-test,203,,,Missing,"[214, 221): 'Windass'",PER,,,TRUE,TRUE,TRUE,TRUE
-test,204,"[283, 290): 'Wallaby'",ORG,Tag,"[283, 290): 'Wallaby'",MISC,,"""aï¿½Wallabyï¿½jersey"" --> Team name as adjective",FALSE,TRUE,FALSE,TRUE
-test,204,,,Missing,"[717, 725): 'Super 12'",MISC,,https://en.wikipedia.org/wiki/Super_Rugby,FALSE,TRUE,TRUE,TRUE
-test,205,"[627, 636): 'Wimbledon'",LOC,Tag,"[627, 636): 'Wimbledon'",ORG,,,TRUE,TRUE,TRUE,TRUE
-test,207,"[1041, 1047): 'Oxford'",LOC,Tag,"[1041, 1047): 'Oxford'",ORG,,Soccer team,TRUE,TRUE,TRUE,TRUE
-test,207,"[1304, 1314): 'Portsmouth'",Loc,Tag,"[1304, 1314): 'Portsmouth'",ORG,16,Soccer team,TRUE,FALSE,FALSE,FALSE
-test,207,"[1304, 1314): 'Portsmouth'",LOC,Tag,"[1304, 1314): 'Portsmouth'",ORG,17,,TRUE,TRUE,FALSE,FALSE
-test,209,"[384, 388): 'East'",ORG,Sentence,"[384, 393): 'East Fife'",ORG,,"Sentence boundary between ""East"" and ""Fife""",FALSE,TRUE,TRUE,TRUE
-test,211,"[54, 61): 'WALLABY'",LOC,Tag,"[54, 61): 'WALLABY'",ORG,16,Team,FALSE,TRUE,FALSE,FALSE
-test,213,"[451, 455): 'Mark'",PER,Sentence,"[451, 463): 'Mark Murless'",PER,,Sentence boundary between first and last names,TRUE,TRUE,TRUE,TRUE
-test,213,"[525, 530): 'Merwe'",PER,Sentence,"[510, 530): 'Schalk van der Merwe'",PER,,Sentence boundary between first and last names,TRUE,TRUE,TRUE,TRUE
-test,213,"[510, 524): 'Schalk van der'",PER,Sentence,"[510, 530): 'Schalk van der Merwe'",,17,,FALSE,TRUE,FALSE,FALSE
-test,213,"[696, 700): 'Dion'",PER,Sentence,"[696, 707): 'Dion Fourie'",PER,,Sentence boundary between first and last names,TRUE,TRUE,TRUE,TRUE
-test,214,"[243, 262): 'Saturday'sWorld Cup'",MISC,Token,"[253, 262): 'World Cup'",MISC,,"Tokenizer treated ""Saturday'sWorld"" as a single token",FALSE,FALSE,FALSE,TRUE
-test,214,"[292, 308): 'Northern Ireland'",LOC,Tag,"[292, 308): 'Northern Ireland'",ORG,,Soccer team,FALSE,FALSE,FALSE,TRUE
-test,214,"[30, 37): 'ALBANIA'",LOC,Tag,"[30, 37): 'ALBANIA'",ORG,14,Team,FALSE,TRUE,FALSE,FALSE
-test,214,"[351, 358): 'Albania'",LOC,Tag,"[351, 358): 'Albania'",ORG,,Soccer team,FALSE,FALSE,FALSE,TRUE
-test,214,"[474, 481): 'Albania'",LOC,Tag,"[474, 481): 'Albania'",ORG,,Soccer team,FALSE,FALSE,FALSE,TRUE
-test,214,"[58, 67): 'N.IRELAND'",LOC,Tag,"[58, 67): 'N.IRELAND'",ORG,,Soccer team,FALSE,FALSE,FALSE,TRUE
-test,215,"[1035, 1043): 'Victoria'",LOC,Tag,"[1035, 1043): 'Victoria'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-test,215,"[161, 169): 'Victoria'",LOC,Tag,"[161, 169): 'Victoria'",ORG,,Cricket team,FALSE,FALSE,TRUE,TRUE
-test,215,"[310, 318): 'Victoria'",LOC,Tag,"[310, 318): 'Victoria'",ORG,,Cricket team,FALSE,TRUE,TRUE,TRUE
-test,215,"[987, 991): 'Pace'",PER,Wrong,,,17,Fred: https://en.wikipedia.org/wiki/Pace_bowling,TRUE,TRUE,FALSE,FALSE
-test,216,"[20, 36): 'SHEFFIELD SHIELD'",MISC,Tag,"[20, 36): 'SHEFFIELD SHIELD'",ORG,17,,FALSE,TRUE,FALSE,FALSE
-test,217,"[19, 30): 'SOUTH KOREA'",LOC,Tag,"[19, 30): 'SOUTH KOREA'",ORG,14,,FALSE,TRUE,FALSE,FALSE
-test,218,"[865, 877): 'Ironi Rishon'",ORG,Span,"[865, 884): 'Ironi Rishon Lezion'",,,,FALSE,TRUE,TRUE,TRUE
-test,219,"[109, 129): 'United Arab Emirates'",LOC,Tag,"[109, 129): 'United Arab Emirates'",ORG,7,,TRUE,FALSE,FALSE,FALSE
-test,219,"[132, 138): 'Kuwait'",LOC,Tag,"[132, 138): 'Kuwait'",ORG,8,Soccer team,TRUE,FALSE,FALSE,FALSE
-test,219,"[165, 168): 'UAE'",LOC,Tag,"[165, 168): 'UAE'",ORG,,Soccer team,FALSE,FALSE,FALSE,TRUE
-test,219,"[223, 229): 'Kuwait'",LOC,Tag,"[223, 229): 'Kuwait'",ORG,,Soccer team,FALSE,FALSE,FALSE,TRUE
-test,219,"[274, 285): 'South Korea'",LOC,Tag,"[274, 285): 'South Korea'",ORG,,Soccer team,FALSE,FALSE,FALSE,TRUE
-test,219,"[288, 297): 'Indonesia'",LOC,Tag,"[288, 297): 'Indonesia'",ORG,8,Soccer team,TRUE,FALSE,FALSE,FALSE
-test,219,"[315, 326): 'South Korea'",LOC,Tag,"[315, 326): 'South Korea'",ORG,,Soccer team,FALSE,FALSE,FALSE,TRUE
-test,219,"[368, 371): 'Koo'",PER,Sentence,"[368, 381): 'Koo Jeon Woon'",PER,,"Sentence boundary between ""Koo"" and ""Jeon Woon""",FALSE,TRUE,TRUE,TRUE
-test,219,"[385, 394): 'Indonesia'",LOC,Tag,"[385, 394): 'Indonesia'",ORG,,Soccer team,FALSE,FALSE,FALSE,TRUE
-test,219,"[536, 547): 'South Korea'",LOC,Tag,"[536, 547): 'South Korea'",ORG,,Soccer team,FALSE,FALSE,FALSE,TRUE
-test,219,"[562, 565): 'UAE'",LOC,Tag,"[562, 565): 'UAE'",ORG,,,TRUE,TRUE,TRUE,TRUE
-test,219,"[580, 586): 'Kuwait'",LOC,Tag,"[580, 586): 'Kuwait'",ORG,16,team,FALSE,TRUE,FALSE,FALSE
-test,219,"[601, 610): 'Indonesia'",LOC,Tag,"[601, 610): 'Indonesia'",ORG,9,Soccer team,TRUE,FALSE,TRUE,FALSE
-test,220,"[1072, 1079): 'ATLANTA'",LOC,Tag,"[1072, 1079): 'ATLANTA'",ORG,15,Team,FALSE,TRUE,FALSE,FALSE
-test,220,"[1203, 1210): 'HOUSTON'",LOC,Tag,"[1203, 1210): 'HOUSTON'",ORG,13,team,FALSE,TRUE,FALSE,FALSE
-test,220,"[76, 95): 'National Basketball'",ORG,Sentence,"[76, 107): 'National Basketball Association'",ORG,,"Sentence boundary between ""Basketball"" and ""Association""",FALSE,FALSE,FALSE,TRUE
-test,220,"[92, 100): 'National'",ORG,Sentence,"[92, 123): 'National Basketball Association'",,17,,FALSE,TRUE,FALSE,FALSE
-test,220,"[415, 431): 'CENTRAL DIVISION'",MISC,Wrong,,,17,"Zach: CHECK: what do we do in cases like these. I'm leaving atlantic cause atlantic is a reigon, but divisions donÕt count Iirc; Fred: Dicisions of leagues not considered entities",FALSE,TRUE,FALSE,FALSE
-test,221,"[76, 95): 'National Basketball'",ORG,Sentence,"[76, 107): 'National Basketball Association'",,17,,FALSE,TRUE,FALSE,FALSE
-test,222,"[1108, 1118): 'NEW JERSEY'",LOC,Tag,"[1108, 1118): 'NEW JERSEY'",ORG,,Hockey team,FALSE,FALSE,FALSE,TRUE
-test,222,"[1130, 1136): 'BOSTON'",LOC,Tag,"[1130, 1136): 'BOSTON'",ORG,,Hockey team,FALSE,FALSE,FALSE,TRUE
-test,222,"[1148, 1156): 'HARTFORD'",LOC,Tag,"[1148, 1156): 'HARTFORD'",ORG,,Hockey team,FALSE,FALSE,FALSE,TRUE
-test,222,"[1171, 1183): 'NY ISLANDERS'",LOC,Tag,"[1171, 1183): 'NY ISLANDERS'",ORG,,Hockey team,TRUE,TRUE,TRUE,TRUE
-test,222,"[1195, 1203): 'MONTREAL'",LOC,Tag,"[1195, 1203): 'MONTREAL'",ORG,,Hockey team,FALSE,FALSE,FALSE,TRUE
-test,222,"[1218, 1225): 'TORONTO'",LOC,Tag,"[1218, 1225): 'TORONTO'",ORG,,Hockey team,FALSE,FALSE,FALSE,TRUE
-test,222,"[1237, 1247): 'PITTSBURGH'",LOC,Tag,"[1237, 1247): 'PITTSBURGH'",ORG,,Hockey team,FALSE,FALSE,FALSE,TRUE
-test,222,"[1260, 1271): 'LOS ANGELES'",LOC,Tag,"[1260, 1271): 'LOS ANGELES'",ORG,,Hockey team,FALSE,FALSE,FALSE,TRUE
-test,222,"[1285, 1293): 'SAN JOSE'",LOC,Tag,"[1285, 1293): 'SAN JOSE'",ORG,15,team,FALSE,TRUE,FALSE,FALSE
-test,222,"[1304, 1313): 'VANCOUVER'",LOC,Tag,"[1304, 1313): 'VANCOUVER'",ORG,,Hockey team,FALSE,FALSE,FALSE,TRUE
-test,222,"[92, 107): 'National Hockey'",ORG,Sentence,"[76, 98): 'National Hockey League'",ORG,,"Sentence boundary between ""Hockey"" and ""League""",FALSE,TRUE,FALSE,TRUE
-test,222,"[108, 114): 'League'",ORG,Sentence,"[92, 114): 'National Hockey League'",ORG,,"Sentence boundary between ""Hockey"" and ""League""",FALSE,FALSE,TRUE,TRUE
-test,222,"[92, 107): 'National Hockey'",ORG,Sentence,"[92, 114): 'National Hockey League'",,17,,TRUE,TRUE,FALSE,FALSE
-test,223,"[231, 243): 'Philadelphia'",LOC,Tag,"[231, 243): 'Philadelphia'",ORG,,,TRUE,TRUE,TRUE,TRUE
-test,223,"[246, 252): 'DALLAS'",LOC,Tag,"[246, 252): 'DALLAS'",ORG,,,TRUE,TRUE,TRUE,TRUE
-test,223,"[255, 263): 'St Louis'",LOC,Tag,"[255, 263): 'St Louis'",ORG,,,TRUE,TRUE,TRUE,TRUE
-test,223,"[266, 274): 'COLORADO'",LOC,Tag,"[266, 274): 'COLORADO'",ORG,,,TRUE,TRUE,TRUE,TRUE
-test,223,"[277, 285): 'EDMONTON'",LOC,Tag,"[277, 285): 'EDMONTON'",ORG,,,TRUE,TRUE,TRUE,TRUE
-test,223,"[288, 294): 'Ottawa'",LOC,Tag,"[288, 294): 'Ottawa'",ORG,,,TRUE,TRUE,TRUE,TRUE
-test,223,"[92, 98): 'League'",ORG,Sentence,"[76, 98): 'National Hockey League'",ORG,,"Sentence boundary between ""Hockey"" and ""League""",TRUE,TRUE,TRUE,TRUE
-test,223,"[76, 91): 'National Hockey'",ORG,Sentence,"[76, 98): 'National Hockey League'",,17,,TRUE,TRUE,FALSE,FALSE
-test,227,"[19, 25): 'BALKAN'",LOC,Tag,"[19, 25): 'BALKAN'",MISC,16,REPEAT -- Whats going on ,FALSE,TRUE,FALSE,FALSE
-test,227,"[99, 105): 'Balkan'",LOC,Tag,"[99, 105): 'Balkan'",MISC,17,,FALSE,TRUE,FALSE,FALSE
-test,228,"[771, 795): 'De Graafschap Doetinchem'",ORG,Tag,"[771, 795): 'De Graafschap Doetinchem'",LOC,17,,FALSE,TRUE,FALSE,FALSE
-test,229,"[703, 711): 'Sporting'",,Span,"[703, 717): 'Sporting Gijon'",,,,FALSE,TRUE,FALSE,TRUE
-test,229,"[703, 711): 'Sporting'",ORG,Span,"[703, 717): 'Sporting Gijon'",ORG,14,soccer team,TRUE,FALSE,FALSE,FALSE
-test,229,"[703, 711): 'Sporting'",ORG,Span,"[703,717): 'Sporting Gijon'",ORG,17,,FALSE,TRUE,FALSE,FALSE
-test ,186,"[1398, 1409): 'Austria)118'",,Token,"[1398, 1405): 'Austria'",LOC,,Token and Missing ,FALSE,FALSE,FALSE,TRUE
-train,6,"[121, 137): 'Toronto Dominion'",PER,Tag,"[121, 137): 'Toronto Dominion'",ORG,,TD Bank,FALSE,TRUE,TRUE,TRUE
-train,11,"[485, 491): 'Rajavi'",MISC,Tag,"[485, 491): 'Rajavi'",PER,,Massoud Rajavi,FALSE,FALSE,TRUE,TRUE
-train,29,"[459, 468): 'Mickelson'",,Sentence,"[454, 468): 'Phil Mickelson'",,,Sentence boundary between first and last name,FALSE,TRUE,FALSE,TRUE
-train,29,"[767, 774): 'O'Meara'",,Sentence,"[762, 774): 'Mark O'Meara'",,,Sentence boundary between first and last name,FALSE,TRUE,FALSE,TRUE
-train,29,"[886, 893): 'Shigeki'",PER,Sentence,"[886, 902): 'Shigeki Maruyama'",,,Sentence boundary between first and last name,FALSE,FALSE,TRUE,TRUE
-train,36,"[115, 134): 'County Championship'",MISC,Span,"[107, 134): 'English County Championship'",,,,FALSE,TRUE,FALSE,TRUE
-train,36,"[20, 47): 'ENGLISH COUNTY CHAMPIONSHIP'",MISC,Span,"[20, 27): 'ENGLISH'",MISC,,First sentence of article correctly separates these two entities,FALSE,FALSE,FALSE,TRUE
-train,36,"[20, 47): 'ENGLISH COUNTY CHAMPIONSHIP'",MISC,Span,"[28, 47): 'COUNTY CHAMPIONSHIP'",MISC,,First sentence of article correctly separates these two entities,FALSE,FALSE,FALSE,TRUE
-train,37,"[144, 151): 'England'",LOC,Tag,"[144, 151): 'England'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-train,37,"[156, 164): 'Pakistan'",LOC,Tag,"[156, 164): 'Pakistan'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-train,37,"[190, 197): 'England'",LOC,Tag,"[190, 197): 'England'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-train,37,"[20, 27): 'ENGLAND'",LOC,Tag,"[20, 27): 'ENGLAND'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-train,37,"[30, 38): 'PAKISTAN'",LOC,Tag,"[30, 38): 'PAKISTAN'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-train,37,"[842, 846): 'Khan'",PER,Sentence,"[837, 846): 'Moin Khan'",,,Sentence boundary between first and last name,FALSE,TRUE,TRUE,TRUE
-train,41,"[370, 378): 'Republic'",LOC,Sentence,"[364, 378): 'Czech Republic'",,,"Sentence boundary between ""Czech"" and ""Republic""",FALSE,TRUE,TRUE,TRUE
-train,42,"[200, 206): 'Millns'",MISC,Tag,"[200, 206): 'Millns'",PER,,,FALSE,FALSE,TRUE,TRUE
-train,42,"[234, 241): 'England'",LOC,Both,"[234, 243): 'England A'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-train,43,"[2111, 2117): 'Batumi'",ORG,Sentence,"[2104, 2117): 'Dynamo Batumi'",,,"Sentence boundary between ""Dynamo"" and ""Batumi""",FALSE,TRUE,TRUE,TRUE
-train,43,"[2364, 2368): 'Petr'",PER,Sentence,"[2364, 2376): 'Petr Gabriel'",,,Sentence boundary between first and last name,FALSE,TRUE,TRUE,TRUE
-train,43,"[2682, 2690): 'Chisinau'",ORG,Sentence,"[2668, 2690): 'Constructorul Chisinau'",,,"Sentence boundary between ""Constructorul"" and ""Chisinau""",FALSE,TRUE,TRUE,TRUE
-train,43,"[2765, 2777): 'Anjalonkoski'",MISC,Tag,"[2765, 2777): 'Anjalonkoski'",LOC,,,FALSE,FALSE,TRUE,TRUE
-train,43,"[2765, 2777): 'Anjalonkoski'",LOC,Tag,"[2765, 2777): 'Anjalonkoski'",LOC,,https://en.wikipedia.org/wiki/Anjalankoski,FALSE,TRUE,FALSE,TRUE
-train,43,"[107, 110): 'Cup'",MISC,Sentence,"[84, 110): 'European Cup Winners ' Cup'",,,"Sentence boundary between ""Winners"" and ""Cup""",FALSE,TRUE,TRUE,TRUE
-train,47,"[229, 235): 'Sun-ho'",MISC,Both,"[223, 235): 'Hwang Sun-ho'",PER,,,FALSE,FALSE,TRUE,TRUE
-train,47,"[85, 94): 'Malaysian'",MISC,Sentence,"[85, 99): 'Malaysian Open'",MISC,,,FALSE,FALSE,TRUE,TRUE
-train,47,"[229, 235): 'Sun-ho'",MISC,Wrong,,,,,FALSE,TRUE,FALSE,TRUE
-train,48,"[157, 160): 'U.S'",LOC,Sentence,"[157, 184): 'U.S. National Tennis Centre'",,,"Sentence boundary between ""U.S."" and ""National""",FALSE,FALSE,TRUE,TRUE
-train,50,"[1249, 1257): 'COLORADO'",LOC,Tag,"[1249, 1257): 'COLORADO'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,50,"[1272, 1279): 'ATLANTA'",LOC,Tag,"[1272, 1279): 'ATLANTA'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,50,"[1294, 1301): 'HOUSTON'",LOC,Tag,"[1294, 1301): 'HOUSTON'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,50,"[1318, 1329): 'LOS ANGELES'",LOC,Tag,"[1318, 1329): 'LOS ANGELES'",ORG,,Baseball team,FALSE,FALSE,TRUE,TRUE
-train,50,"[1342, 1355): 'SAN FRANCISCO'",LOC,Tag,"[1342, 1355): 'SAN FRANCISCO'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,50,"[672, 678): 'BOSTON'",LOC,Tag,"[672, 678): 'BOSTON'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,50,"[690, 699): 'BALTIMORE'",LOC,Tag,"[690, 699): 'BALTIMORE'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,50,"[714, 722): 'NEW YORK'",LOC,Tag,"[714, 722): 'NEW YORK'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,50,"[734, 741): 'CHICAGO'",LOC,Tag,"[734, 741): 'CHICAGO'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,50,"[753, 764): 'KANSAS CITY'",LOC,Tag,"[753, 764): 'KANSAS CITY'",ORG,,Baseball team,FALSE,FALSE,TRUE,TRUE
-train,50,"[774, 783): 'MINNESOTA'",LOC,Tag,"[774, 783): 'MINNESOTA'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,50,"[234, 250): 'EASTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-train,50,"[375, 391): 'CENTRAL DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-train,50,"[525, 541): 'WESTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-train,50,"[800, 816): 'EASTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-train,50,"[947, 963): 'CENTRAL DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-train,50,"[1086, 1102): 'WESTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-train,51,"[84, 96): 'Major League'",MISC,Sentence,"[84, 105): 'Major League Baseball'",,,"Sentence boundary between ""League"" and ""Baseball""",FALSE,TRUE,FALSE,TRUE
-train,52,"[2054, 2063): 'Baltimore'",LOC,Tag,"[2054, 2063): 'Baltimore'",ORG,,BaltimoreÊhas won seven of nine and 16 of its last 22,FALSE,TRUE,TRUE,TRUE
-train,52,"[2016, 2019): 'RBI'",MISC,Wrong,,,,Run batted in,FALSE,FALSE,FALSE,TRUE
-train,52,"[2264, 2267): 'RBI'",MISC,Wrong,,,,Runs batted in,FALSE,FALSE,FALSE,TRUE
-train,52,"[3472, 3475): 'RBI'",MISC,Wrong,,,,Runs batted in,FALSE,FALSE,FALSE,TRUE
-train,52,"[4026, 4029): 'ERA'",MISC,Wrong,,,,Earned run average,FALSE,FALSE,FALSE,TRUE
-train,52,"[4230, 4233): 'ERA'",MISC,Wrong,,,,Earned run average,FALSE,FALSE,FALSE,TRUE
-train,52,"[4411, 4414): 'RBI'",MISC,Wrong,,,,Runs batted in,FALSE,FALSE,FALSE,TRUE
-train,52,"[4448, 4451): 'RBI'",MISC,Wrong,,,,Runs batted in,FALSE,FALSE,FALSE,TRUE
-train,54,,,Missing,"[176, 181): 'Numan'",PER,,,FALSE,TRUE,TRUE,TRUE
-train,56,"[171, 182): 'Switzerland'",LOC,Tag,"[171, 182): 'Switzerland'",ORG,,Soccer team,FALSE,FALSE,FALSE,TRUE
-train,56,"[219, 229): 'Azerbaijan'",LOC,Tag,"[219, 229): 'Azerbaijan'",ORG,,Soccer team,FALSE,FALSE,FALSE,TRUE
-train,56,"[442, 453): 'Switzerland'",LOC,Tag,"[442, 453): 'Switzerland'",ORG,,Soccer team,FALSE,FALSE,FALSE,TRUE
-train,56,"[829, 838): 'Stuttgart'",LOC,Tag,"[829, 838): 'Stuttgart'",ORG,,Soccer team,FALSE,FALSE,FALSE,TRUE
-train,56,"[859, 867): 'Lausanne'",LOC,Tag,"[859, 867): 'Lausanne'",ORG,,Soccer team,FALSE,FALSE,TRUE,TRUE
-train,58,"[1096, 1102): 'Spence'",PER,Sentence,"[1090, 1102): 'Jamie Spence'",PER,,Sentence boundary between first and last name,FALSE,FALSE,TRUE,TRUE
-train,58,"[1090, 1095): 'Jamie'",PER,Sentence,"[1090, 1102): 'Jamie Spence'",,,Sentence boundary between first and last name,FALSE,TRUE,FALSE,TRUE
-train,58,"[271, 274): 'Ian'",PER,Sentence,"[271, 282): 'Ian Woosnam'",PER,,Sentence boundary between first and last name,FALSE,FALSE,TRUE,TRUE
-train,58,"[332, 338): 'Lanner'",PER,Sentence,"[327, 338): 'Mats Lanner'",PER,,Sentence boundary between first and last name,FALSE,FALSE,TRUE,TRUE
-train,58,"[327, 331): 'Mats'",PER,Sentence,"[327, 338): 'Mats Lanner'",,,Sentence boundary between first and last name,FALSE,TRUE,FALSE,TRUE
-train,58,"[653, 661): 'Chalmers'",PER,Sentence,"[648, 661): 'Greg Chalmers'",,,Sentence boundary between first and last name,FALSE,TRUE,FALSE,TRUE
-train,58,"[648, 652): 'Greg'",PER,Sentence,"[648, 661): 'Greg Chalmers'",PER,,Sentence boundary between first and last name,FALSE,FALSE,TRUE,TRUE
-train,58,"[751, 758): 'Derrick'",PER,Sentence,"[751, 765): 'Derrick Cooper'",,,Sentence boundary between first and last name,FALSE,TRUE,FALSE,TRUE
-train,58,"[759, 765): 'Cooper'",PER,Sentence,"[751, 765): 'Derrick Cooper'",PER,,Sentence boundary between first and last name,FALSE,FALSE,TRUE,TRUE
-train,58,"[824, 829): 'Welch'",PER,Sentence,"[816, 829): 'Michael Welch'",,,Sentence boundary between first and last name,FALSE,TRUE,FALSE,TRUE
-train,58,"[816, 823): 'Michael'",PER,Sentence,"[816, 829): 'Michael Welch'",PER,,Sentence boundary between first and last name,FALSE,FALSE,TRUE,TRUE
-train,70,,,Missing,"[306, 315): 'Soufriere'",LOC,,City in Saint Lucia,FALSE,FALSE,FALSE,TRUE
-train,70,"[424, 432): 'Plymouth'",ORG,Tag,"[424, 432): 'Plymouth'",LOC,,,FALSE,FALSE,TRUE,TRUE
-train,80,,,Token,"[44, 59): 'Interfax'",ORG,,"Missing annotation, and 'rebels-Interfax' treated as a single token",FALSE,TRUE,FALSE,TRUE
-train,80,,,Token,"[51, 59): 'Interfax'",ORG,,"Tokenizer treats ""rebels-Interfax"" as a single token",FALSE,FALSE,TRUE,TRUE
-train,98,,,Missing,"[81, 85): 'N.M.'",LOC,,,FALSE,TRUE,TRUE,TRUE
-train,115,,,Token,"[23, 27): 'News'",,,"FOCUS-News' treated as a single token; ""News"" is a reference to News Corp Ltd",FALSE,TRUE,FALSE,TRUE
-train,119,,,Missing,"[11, 16): 'Thais'",MISC,,,FALSE,TRUE,TRUE,TRUE
-train,119,,,Missing,"[826, 831): 'Vivit'",PER,,,FALSE,TRUE,TRUE,TRUE
-train,122,"[436, 444): 'Chua Jui'",PER,Span,"[436, 449): 'Chua Jui Meng'",,,,FALSE,FALSE,TRUE,TRUE
-train,136,"[1022, 1027): 'Wasim'",PER,Sentence,"[1022, 1033): 'Wasim Akram'",PER,,Sentence boundary between first and last name,FALSE,FALSE,TRUE,TRUE
-train,136,"[1028, 1033): 'Akram'",PER,Sentence,"[1022, 1033): 'Wasim Akram'",,,Sentence boundary between first and last name,FALSE,TRUE,FALSE,TRUE
-train,136,"[145, 152): 'England'",LOC,Tag,"[145, 152): 'England'",ORG,,the third and final test betweenï¿½Englandï¿½andï¿½Pakistan,FALSE,FALSE,FALSE,TRUE
-train,136,"[157, 165): 'Pakistan'",LOC,Tag,"[157, 165): 'Pakistan'",ORG,,the third and final test betweenï¿½Englandï¿½andï¿½Pakistan,FALSE,FALSE,FALSE,TRUE
-train,136,"[169, 172): 'The'",LOC,Sentence,"[169, 177): 'The Oval'",LOC,,"Sentence boundary between ""The"" and ""Oval""",FALSE,FALSE,TRUE,TRUE
-train,136,"[173, 177): 'Oval'",LOC,Sentence,"[169, 177): 'The Oval'",,,"Sentence boundary between ""The"" and ""Oval""",FALSE,TRUE,FALSE,TRUE
-train,136,"[189, 196): 'England'",LOC,Tag,"[189, 196): 'England'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-train,136,"[20, 27): 'ENGLAND'",LOC,Tag,"[20, 27): 'ENGLAND'",ORG,,CRICKET-ï¿½ENGLANDï¿½Vï¿½PAKISTANï¿½FINAL TEST SCOREBOARD,FALSE,FALSE,FALSE,TRUE
-train,136,"[30, 38): 'PAKISTAN'",LOC,Tag,"[30, 38): 'PAKISTAN'",ORG,,CRICKET-ï¿½ENGLANDï¿½Vï¿½PAKISTANï¿½FINAL TEST SCOREBOARD,FALSE,FALSE,FALSE,TRUE
-train,136,"[801, 809): 'Pakistan'",LOC,Tag,"[801, 809): 'Pakistan'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-train,140,"[560, 565): 'Czech'",LOC,Sentence,"[560, 574): 'Czech Republic'",LOC,,"Sentence boundary between ""Czech"" and ""Republic""",FALSE,FALSE,TRUE,TRUE
-train,140,"[566, 574): 'Republic'",LOC,Sentence,"[560, 574): 'Czech Republic'",,,"Sentence boundary between ""Czech"" and ""Republic""",FALSE,TRUE,FALSE,TRUE
-train,142,"[105, 109): 'Open'",MISC,Sentence,"[95, 109): 'Malaysian Open'",,,"Sentence boundary between ""Malaysian"" and ""Open""",FALSE,TRUE,FALSE,TRUE
-train,142,"[95, 104): 'Malaysian'",MISC,Sentence,"[95, 109): 'Malaysian Open'",MISC,,"Sentence boundary between ""Malaysian"" and ""Open""",FALSE,FALSE,TRUE,TRUE
-train,144,"[1255, 1262): 'FLORIDA'",LOC,Tag,"[1255, 1262): 'FLORIDA'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,144,"[1289, 1296): 'ATLANTA'",LOC,Tag,"[1289, 1296): 'ATLANTA'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,144,"[1309, 1316): 'HOUSTON'",LOC,Tag,"[1309, 1316): 'HOUSTON'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,144,"[1331, 1339): 'COLORADO'",LOC,Tag,"[1331, 1339): 'COLORADO'",ORG,,Baseball team,FALSE,FALSE,TRUE,TRUE
-train,144,"[1352, 1363): 'LOS ANGELES'",LOC,Tag,"[1352, 1363): 'LOS ANGELES'",ORG,,Baseball team,FALSE,FALSE,TRUE,TRUE
-train,144,"[655, 661): 'BOSTON'",LOC,Tag,"[655, 661): 'BOSTON'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,144,"[675, 684): 'CLEVELAND'",LOC,Tag,"[675, 684): 'CLEVELAND'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,144,"[699, 708): 'BALTIMORE'",LOC,Tag,"[699, 708): 'BALTIMORE'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,144,"[720, 728): 'NEW YORK'",LOC,Tag,"[720, 728): 'NEW YORK'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,144,"[740, 747): 'CHICAGO'",LOC,Tag,"[740, 747): 'CHICAGO'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,144,"[759, 770): 'KANSAS CITY'",LOC,Tag,"[759, 770): 'KANSAS CITY'",ORG,,Baseball team,FALSE,FALSE,TRUE,TRUE
-train,144,"[232, 248): 'EASTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-train,144,"[372, 388): 'CENTRAL DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-train,144,"[510, 526): 'WESTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-train,144,"[806, 822): 'EASTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-train,144,"[953, 969): 'CENTRAL DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-train,144,"[1096, 1112): 'WESTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-train,145,"[83, 95): 'Major League'",MISC,Sentence,"[83, 104): 'Major League Baseball'",MISC,,"Sentence boundary between ""League"" and ""Baseball""",FALSE,FALSE,TRUE,TRUE
-train,158,"[684, 690): 'Jonzon'",PER,Sentence,"[676, 690): 'Michael Jonzon'",PER,,Sentence boundary between first and last name,FALSE,FALSE,TRUE,TRUE
-train,158,"[676, 683): 'Michael'",PER,Sentence,"[676, 690): 'Michael Jonzon'",,,Sentence boundary between first and last name,FALSE,TRUE,FALSE,TRUE
-train,158,"[837, 842): 'Riley'",PER,Sentence,"[831, 842): 'Wayne Riley'",PER,,Sentence boundary between first and last name,FALSE,FALSE,TRUE,TRUE
-train,158,"[831, 836): 'Wayne'",PER,Sentence,"[831, 842): 'Wayne Riley'",,,Sentence boundary between first and last name,FALSE,TRUE,FALSE,TRUE
-train,158,"[1002, 1007): 'Smyth'",PER,Sentence,"[998, 1007): 'Des Smyth'",PER,,Sentence boundary between first and last name,FALSE,FALSE,TRUE,TRUE
-train,158,"[998, 1001): 'Des'",PER,Sentence,"[998, 1007): 'Des Smyth'",,,Sentence boundary between first and last name,FALSE,TRUE,FALSE,TRUE
-train,163,"[220, 232): 'x-AEK Athens'",ORG,Token,"[222, 232): 'AEK Athens'",ORG,,"Tokenizer treated ""x-AEK"" as a single token",FALSE,FALSE,FALSE,TRUE
-train,163,"[271, 283): 'x-Olympiakos'",ORG,Token,"[273, 283): 'Olympiakos'",ORG,,"Tokenizer treated ""x-Olympiakos"" as a single token",FALSE,FALSE,FALSE,TRUE
-train,163,"[308, 313): 'x-PAO'",ORG,Token,"[310, 313): 'PAO'",ORG,,"Tokenizer treated ""x-PAO"" as a single token",FALSE,FALSE,FALSE,TRUE
-train,169,"[50, 61): 'trip-Canada'",LOC,Token,"[55, 61): 'Canada'",LOC,,"Tokenizer treated ""trip-Canada"" as a single token",FALSE,FALSE,TRUE,TRUE
-train,184,,,Missing,"[419, 427): 'Ministry'",ORG,,,FALSE,FALSE,TRUE,TRUE
-train,208,"[143, 161): 'The Walt Disney Co'",ORG,Sentence,"[143, 162): 'The Walt Disney Co.'",ORG,,"Incorrect sentence boundary after ""Co."" makes it look like the period is not part of the abbreviation when in fact it is",FALSE,FALSE,TRUE,TRUE
-train,208,"[143, 161): 'The Walt Disney Co'",,Span,"[143, 162): 'The Walt Disney Co.'",,,,FALSE,TRUE,FALSE,TRUE
-train,208,"[2962, 2980): 'Kalf, Voorhis & Co'",,Span,"[2962, 2981): 'Kalf, Voorhis & Co.'",,,"Comma after period after ""Co""",FALSE,TRUE,FALSE,TRUE
-train,208,"[2962, 2980): 'Kalf, Voorhis & Co'",ORG,Sentence,"[2962, 2981): 'Kalf, Voorhis & Co.'",ORG,,"Incorrect sentence boundary after ""Co."" makes it look like the period is not part of the abbreviation when in fact it is",FALSE,FALSE,TRUE,TRUE
-train,249,"[247, 252): 'Waqar'",PER,Sentence,"[247, 259): 'Waqar Younis'",,,Sentence boundary between first and last name,FALSE,TRUE,FALSE,TRUE
-train,249,"[253, 259): 'Younis'",PER,Sentence,"[247, 259): 'Waqar Younis'",PER,,Sentence boundary between first and last name,FALSE,FALSE,TRUE,TRUE
-train,262,"[1245, 1252): 'ATLANTA'",LOC,Tag,"[1245, 1252): 'ATLANTA'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,262,"[1265, 1272): 'HOUSTON'",LOC,Tag,"[1265, 1272): 'HOUSTON'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,262,"[1285, 1296): 'LOS ANGELES'",LOC,Tag,"[1285, 1296): 'LOS ANGELES'",ORG,,Baseball team,FALSE,FALSE,TRUE,TRUE
-train,262,"[1309, 1322): 'SAN FRANCISCO'",LOC,Tag,"[1309, 1322): 'SAN FRANCISCO'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,262,"[1337, 1344): 'FLORIDA'",LOC,Tag,"[1337, 1344): 'FLORIDA'",ORG,,Baseball team,FALSE,FALSE,TRUE,TRUE
-train,262,"[1359, 1367): 'COLORADO'",LOC,Tag,"[1359, 1367): 'COLORADO'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,262,"[1384, 1393): 'SAN DIEGO'",LOC,Tag,"[1384, 1393): 'SAN DIEGO'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,262,"[656, 662): 'BOSTON'",LOC,Tag,"[656, 662): 'BOSTON'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,262,"[676, 685): 'CLEVELAND'",LOC,Tag,"[676, 685): 'CLEVELAND'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,262,"[700, 709): 'BALTIMORE'",LOC,Tag,"[700, 709): 'BALTIMORE'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,262,"[721, 728): 'CHICAGO'",LOC,Tag,"[721, 728): 'CHICAGO'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,262,"[740, 748): 'NEW YORK'",LOC,Tag,"[740, 748): 'NEW YORK'",ORG,,Baseball team,FALSE,FALSE,TRUE,TRUE
-train,262,"[760, 771): 'KANSAS CITY'",LOC,Tag,"[760, 771): 'KANSAS CITY'",ORG,,Baseball team,FALSE,FALSE,TRUE,TRUE
-train,262,"[228, 244): 'EASTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-train,262,"[369, 385): 'CENTRAL DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-train,262,"[507, 523): 'WESTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-train,262,"[807, 823): 'EASTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-train,262,"[950, 966): 'CENTRAL DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-train,262,"[1085, 1101): 'WESTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-train,263,"[81, 93): 'Major League'",MISC,Sentence,"[81, 102): 'Major League Baseball'",,,"Sentence boundary between ""League"" and ""Baseball""",FALSE,TRUE,FALSE,TRUE
-train,283,"[866, 874): 'Florence'",LOC,Both,"[866, 883): 'Florence Chitauro'",PER,,,FALSE,TRUE,TRUE,TRUE
-train,287,,,Missing,"[20, 30): 'Socialists'",ORG,,Albania's oppositionï¿½Socialist Party,FALSE,FALSE,FALSE,TRUE
-train,298,"[49, 60): '1997--Ruehe'",MISC,Token,"[55, 60): 'Ruehe'",PER,,"Tokenizer treated ""1997--Ruehe"" as a single token",FALSE,FALSE,TRUE,TRUE
-train,300,"[786, 792): 'Verona'",PER,Tag,"[786, 792): 'Verona'",LOC,,,FALSE,FALSE,TRUE,TRUE
-train,309,"[548, 554): 'Brooks'",PER,Sentence,"[543, 554): 'Mark Brooks'",PER,,Sentence boundary between first and last name,FALSE,FALSE,TRUE,TRUE
-train,309,"[543, 547): 'Mark'",PER,Sentence,"[543, 554): 'Mark Brooks'",,,Sentence boundary between first and last name,FALSE,TRUE,FALSE,TRUE
-train,309,"[661, 668): 'O'Meara'",PER,Sentence,"[656, 668): 'Mark O'Meara'",PER,,Sentence boundary between first and last name,FALSE,FALSE,TRUE,TRUE
-train,309,"[656, 660): 'Mark'",PER,Sentence,"[656, 668): 'Mark O'Meara'",,,Sentence boundary between first and last name,FALSE,TRUE,FALSE,TRUE
-train,309,"[787, 791): 'Fred'",PER,Sentence,"[787, 799): 'Fred Couples'",PER,,Sentence boundary between first and last name,FALSE,FALSE,TRUE,TRUE
-train,309,"[792, 799): 'Couples'",PER,Sentence,"[787, 799): 'Fred Couples'",,,Sentence boundary between first and last name,FALSE,TRUE,FALSE,TRUE
-train,310,"[227, 235): 'Republic'",LOC,Sentence,"[221, 235): 'Czech Republic'",LOC,,"Sentence boundary between ""Czech"" and ""Republic""",FALSE,FALSE,TRUE,TRUE
-train,310,"[221, 226): 'Czech'",LOC,Sentence,"[221, 235): 'Czech Republic'",,,"Sentence boundary between ""Czech"" and ""Republic""",FALSE,TRUE,FALSE,TRUE
-train,310,"[93, 96): 'Cup'",MISC,Sentence,"[86, 96): 'Hamlet Cup'",MISC,,"Sentence boundary between ""Hamlet"" and ""Cup""",FALSE,FALSE,TRUE,TRUE
-train,315,"[1179, 1195): 'Marcos LM600 162'",MISC,Sentence,"[1175, 1191): 'GT2 Marcos LM600'",,,"Sentence boundary between ""GT2"" and ""Marcos""; also ""162"" not part of name",FALSE,TRUE,FALSE,TRUE
-train,315,"[1175, 1178): 'GT2'",MISC,Sentence,"[1175, 1195): 'GT2 Marcos LM600 162'",MISC,,"Sentence boundary between ""GT2"" and ""Marcos""",FALSE,FALSE,FALSE,TRUE
-train,315,,,Missing,"[257, 266): 'J.J.Lehto'",PER,,,FALSE,TRUE,TRUE,TRUE
-train,315,"[424, 429): 'Ennea'",MISC,Sentence,"[424, 441): 'Ennea Ferrari F40'",MISC,,"Sentence boundary between ""Ennea"" and ""Ferrari""",FALSE,FALSE,FALSE,TRUE
-train,315,"[506, 513): 'Harrods'",MISC,Sentence,"[506, 528): 'Harrods McLaren FI GTR'",MISC,,"Sentence boundary between ""GTR"" and ""West""",FALSE,FALSE,TRUE,TRUE
-train,315,"[585, 597): 'West McLaren'",MISC,Sentence,"[585, 604): 'West McLaren F1 GTR'",MISC,,"Sentence boundary between ""McLaren"" and ""F1""",FALSE,FALSE,FALSE,TRUE
-train,315,"[803, 806): 'GTR'",,Sentence,"[787, 806): 'Gulf McLaren F! GTR'",,,"Sentence boundary before ""GTR""",FALSE,TRUE,FALSE,TRUE
-train,315,"[803, 806): 'GTR'",MISC,Sentence,"[787, 806): 'Gulf McLaren F! GTR'",MISC,,"Sentence boundary between ""F!"" (sic.) and ""GTR""",FALSE,FALSE,TRUE,TRUE
-train,315,"[864, 868): 'Paul'",PER,Sentence,"[864, 877): 'Paul Belmondo'",PER,,Sentence boundary between first and last name,FALSE,FALSE,TRUE,TRUE
-train,315,"[869, 877): 'Belmondo'",PER,Sentence,"[864, 877): 'Paul Belmondo'",,,,FALSE,TRUE,FALSE,TRUE
-train,317,"[407, 415): 'Williams'",PER,Tag,"[407, 415): 'Williams'",ORG,,"F1 team; tagged correctly at [272, 280): 'Williams'	",FALSE,TRUE,TRUE,TRUE
-train,318,,,Missing,"[1177, 1185): 'Footwork'",ORG,,https://en.wikipedia.org/wiki/Footwork_Arrows,FALSE,FALSE,FALSE,TRUE
-train,319,"[156, 167): '1,000 Lakes'",MISC,Sentence,"[156, 173): '1,000 Lakes Rally'",,,"Sentence boundary between ""Lakes"" and ""Rally""",FALSE,TRUE,FALSE,TRUE
-train,319,"[168, 173): 'Rally'",MISC,Sentence,"[156, 173): '1,000 Lakes Rally'",MISC,,"Sentence boundary between ""Lakes"" and ""Rally""",FALSE,FALSE,TRUE,TRUE
-train,328,"[145, 152): 'England'",LOC,Tag,"[145, 152): 'England'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-train,328,"[157, 165): 'Pakistan'",LOC,Tag,"[157, 165): 'Pakistan'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-train,328,"[173, 177): 'Oval'",LOC,Sentence,"[169, 177): 'The Oval'",LOC,,"Sentence boundary between ""The"" and ""Oval""",FALSE,FALSE,TRUE,TRUE
-train,328,"[20, 27): 'ENGLAND'",LOC,Tag,"[20, 27): 'ENGLAND'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-train,328,"[252, 258): 'Younis'",PER,Sentence,"[246, 258): 'Waqar Younis'",PER,,Sentence boundary between first and last name,FALSE,FALSE,TRUE,TRUE
-train,328,"[246, 251): 'Waqar'",PER,Sentence,"[246, 258): 'Waqar Younis'",,,Sentence boundary between first and last names,FALSE,TRUE,FALSE,TRUE
-train,328,"[265, 273): 'Pakistan'",LOC,Tag,"[265, 273): 'Pakistan'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-train,328,"[30, 38): 'PAKISTAN'",LOC,Tag,"[30, 38): 'PAKISTAN'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-train,328,"[873, 880): 'England'",LOC,Tag,"[873, 880): 'England'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-train,339,"[546, 553): 'Mariusz'",PER,Sentence,"[546, 560): 'Mariusz Srutwa'",PER,,Sentence boundary between first and last name,FALSE,FALSE,TRUE,TRUE
-train,339,"[554, 560): 'Srutwa'",PER,Sentence,"[546, 560): 'Mariusz Srutwa'",,,Sentence boundary between first and last names,FALSE,TRUE,FALSE,TRUE
-train,343,"[11, 31): 'AUSTRALIAN RULES-AFL'","[11, 21): 'AUSTRALIAN'",Token,MISC,,,"""RULES-AFL"" treated as a single token",FALSE,TRUE,FALSE,TRUE
-train,343,"[11, 31): 'AUSTRALIAN RULES-AFL'","[28, 31): 'AFL'",Token,ORG,,,"""RULES-AFL"" treated as a single token; AFL == Australian Football League",FALSE,TRUE,FALSE,TRUE
-train,343,"[11, 31): 'AUSTRALIAN RULES-AFL'",MISC,Token,"[11, 27): 'AUSTRALIAN RULES'",MISC,,"Tokenizer treated ""RULES-AFL"" as a single token",FALSE,FALSE,TRUE,TRUE
-train,343,"[11, 31): 'AUSTRALIAN RULES-AFL'",MISC,Token,"[28, 31): 'AFL'",MISC,,"Tokenizer treated ""RULES-AFL"" as a single token",FALSE,FALSE,TRUE,TRUE
-train,345,"[536, 541): 'Chong'",PER,Sentence,"[536, 550): 'Chong Tan Fook'",PER,,"Sentence boundary between ""Chong"" and ""Tan""",FALSE,FALSE,TRUE,TRUE
-train,345,"[542, 550): 'Tan Fook'",PER,Sentence,"[536, 550): 'Chong Tan Fook'",,,Sentence boundary between first and middle names,FALSE,TRUE,FALSE,TRUE
-train,346,"[207, 212): 'Lotte'",PER,Tag,"[207, 212): 'Lotte'",ORG,,Baseball team,FALSE,FALSE,TRUE,TRUE
-train,346,"[207, 212): 'Lotte'",,Tag,"[207, 212): 'Lotte'",ORG,,Baseball team,FALSE,TRUE,FALSE,TRUE
-train,346,"[215, 220): 'Lotte'",PER,Tag,"[215, 220): 'Lotte'",ORG,,Baseball team,FALSE,FALSE,TRUE,TRUE
-train,346,"[215, 220): 'Lotte'",,Tag,"[215, 220): 'Lotte'",ORG,,Baseball team,FALSE,TRUE,FALSE,TRUE
-train,346,"[243, 248): 'Lotte'",PER,Tag,"[243, 248): 'Lotte'",ORG,,Baseball team,FALSE,FALSE,TRUE,TRUE
-train,346,"[243, 248): 'Lotte'",,Tag,"[243, 248): 'Lotte'",ORG,,Baseball team,FALSE,TRUE,FALSE,TRUE
-train,347,"[81, 93): 'Major League'",MISC,Sentence,"[81, 102): 'Major League Baseball'",,,"Sentence boundary between ""League"" and ""Baseball""",FALSE,TRUE,FALSE,TRUE
-train,349,"[591, 611): 'Mariner Darren Bragg'",,Both,"[591, 598): 'Mariner'",MISC,,,FALSE,FALSE,FALSE,TRUE
-train,349,"[1001, 1010): 'Cleveland'",ORG,Tag,"[1001, 1010): 'Cleveland'",LOC,,"In Cleveland, Kevin Seitzer's two-out singleï¿½",FALSE,TRUE,TRUE,TRUE
-train,349,"[591, 611): 'Mariner Darren Bragg'",,Span,"[599, 611): 'Darren Bragg'",,,,FALSE,TRUE,FALSE,TRUE
-train,351,"[83, 95): 'Major League'",MISC,Sentence,"[83, 104): 'Major League Baseball'",,,"Sentence boundary between ""League"" and ""Baseball""",FALSE,TRUE,FALSE,TRUE
-train,355,,,Missing,"[175, 185): 'Supercoppa'",MISC,,,FALSE,FALSE,TRUE,TRUE
-train,359,"[386, 389): 'St.'",ORG,Span,"[386, 396): 'St. Gallen'",,,,FALSE,TRUE,TRUE,TRUE
-train,366,"[667, 675): 'Waalwijk'",ORG,Sentence,"[663, 675): 'RKC Waalwijk'",ORG,,"Sentence boundary between ""RKC"" and ""Waalwijk""",FALSE,FALSE,TRUE,TRUE
-train,366,"[663, 666): 'RKC'",ORG,Sentence,"[663, 675): 'RKC Waalwijk'",,,"Sentence boundary between ""RKC"" and ""Waalwijk""",FALSE,TRUE,FALSE,TRUE
-train,369,"[1086, 1095): 'Australia'",LOC,Tag,"[1086, 1095): 'Australia'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-train,369,"[567, 574): 'England'",LOC,Tag,"[567, 574): 'England'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-train,369,"[905, 913): 'Pakistan'",LOC,Tag,"[905, 913): 'Pakistan'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-train,402,"[127, 138): 'Lakes Rally'",MISC,Sentence,"[121, 138): '1,000 Lakes Rally'",MISC,,"Sentence boundary between ""1,000"" and ""Lakes""",FALSE,FALSE,TRUE,TRUE
-train,402,"[121, 126): '1,000'",MISC,Sentence,"[121, 138): '1,000 Lakes Rally'",,,"Sentence boundary between ""1,000"" and ""Lakes""",FALSE,TRUE,FALSE,TRUE
-train,412,"[250, 256): 'Younis'",PER,Sentence,"[244, 256): 'Waqar Younis'",PER,,Sentence boundary between first and last name,FALSE,FALSE,TRUE,TRUE
-train,415,"[1153, 1159): 'Morton'",ORG,Sentence,"[1144, 1159): 'Greenock Morton'",ORG,,"Sentence boundary between ""Greenock"" and ""Morton""",FALSE,FALSE,TRUE,TRUE
-train,415,"[1144, 1152): 'Greenock'",ORG,Sentence,"[1144, 1159): 'Greenock Morton'",,,"Sentence boundary between ""Greenock"" and ""Morton""",FALSE,TRUE,FALSE,TRUE
-train,415,"[1299, 1304): 'South'",ORG,Sentence,"[1286, 1304): 'Queen of the South'",ORG,,"Sentence boundary between ""the"" and ""South""",FALSE,FALSE,TRUE,TRUE
-train,415,"[1286, 1298): 'Queen of the'",ORG,Sentence,"[1286, 1304): 'Queen of the South'",,,"Sentence boundary between ""the"" and ""South""",FALSE,TRUE,FALSE,TRUE
-train,422,"[236, 246): 'Videoton(*'",ORG,Token,"[236, 244): 'Videoton'",,,"""Videoton(*"" treated as a single token",FALSE,FALSE,FALSE,TRUE
-train,422,"[736, 743): 'Stadler'",ORG,Span,"[736, 746): 'Stadler FC'",,,,FALSE,TRUE,TRUE,TRUE
-train,436,"[3087, 3095): 'Perfetti'",PER,Span,"[3081, 3095): 'Flora Perfetti'",PER,,,FALSE,FALSE,TRUE,TRUE
-train,436,"[3081, 3086): 'Flora'",LOC,Wrong,,,,,FALSE,FALSE,TRUE,TRUE
-train,437,"[837, 845): 'Castilla'",ORG,Tag,"[837, 845): 'Castilla'",PER,,,FALSE,FALSE,FALSE,TRUE
-train,437,"[727, 730): 'RBI'",MISC,Wrong,,,,Runs batted in,FALSE,FALSE,FALSE,TRUE
-train,437,"[2460, 2463): 'RBI'",MISC,Wrong,,,,Runs batted in,FALSE,FALSE,FALSE,TRUE
-train,438,"[1230, 1243): 'SAN FRANCISCO'",LOC,Tag,"[1230, 1243): 'SAN FRANCISCO'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,438,"[1256, 1263): 'HOUSTON'",LOC,Tag,"[1256, 1263): 'HOUSTON'",ORG,,Baseball team,FALSE,TRUE,TRUE,TRUE
-train,438,"[1278, 1286): 'COLORADO'",LOC,Tag,"[1278, 1286): 'COLORADO'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,438,"[655, 662): 'DETROIT'",LOC,Tag,"[655, 662): 'DETROIT'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,438,"[674, 683): 'BALTIMORE'",LOC,Tag,"[674, 683): 'BALTIMORE'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,438,"[697, 704): 'TORONTO'",LOC,Tag,"[697, 704): 'TORONTO'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,438,"[718, 725): 'CHICAGO'",LOC,Tag,"[718, 725): 'CHICAGO'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,438,"[736, 746): 'CALIFORNIA'",LOC,Tag,"[736, 746): 'CALIFORNIA'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,438,"[759, 766): 'SEATTLE'",LOC,Tag,"[759, 766): 'SEATTLE'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,438,"[228, 244): 'EASTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-train,438,"[368, 384): 'CENTRAL DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-train,438,"[506, 522): 'WESTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-train,438,"[783, 799): 'EASTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-train,438,"[926, 942): 'CENTRAL DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-train,438,"[1067, 1083): 'WESTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-train,444,"[122, 128): 'Series'",MISC,Sentence,"[109, 128): 'Singer World Series'",MISC,,"Sentence boundary between ""World"" and ""Series""",FALSE,FALSE,TRUE,TRUE
-train,444,"[109, 121): 'Singer World'",MISC,Sentence,"[109, 128): 'Singer World Series'",,,"Sentence boundary between ""World"" and ""Series""",FALSE,TRUE,FALSE,TRUE
-train,444,"[1359, 1368): 'Australia'",LOC,Tag,"[1359, 1368): 'Australia'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-train,444,"[170, 179): 'Australia'",LOC,Tag,"[170, 179): 'Australia'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-train,444,"[184, 192): 'Zimbabwe'",LOC,Tag,"[184, 192): 'Zimbabwe'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-train,444,"[204, 213): 'Australia'",LOC,Tag,"[204, 213): 'Australia'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-train,444,"[761, 769): 'Zimbabwe'",LOC,Tag,"[761, 769): 'Zimbabwe'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-train,458,"[1294, 1300): 'Nicola'",MISC,Both,"[1294, 1310): 'Nicola Fleuchaus'",PER,,,FALSE,TRUE,FALSE,TRUE
-train,458,"[1301, 1310): 'Fleuchaus'",PER,Span,"[1294, 1310): 'Nicola Fleuchaus'",,,,FALSE,TRUE,FALSE,TRUE
-train,458,"[1294, 1300): 'Nicola'",MISC,Wrong,,,,,FALSE,FALSE,TRUE,TRUE
-train,458,"[363, 366): 'Col'",LOC,Wrong,,,,"Abbreviation for ""Colonel"". Titles not considered entities; also tagged as LOC, which is doubly wrong",FALSE,FALSE,FALSE,TRUE
-train,487,,,Missing,"[911, 916): 'NYMEX'",ORG,,,FALSE,FALSE,TRUE,TRUE
-train,492,,,Missing,"[224, 257): 'OCASEK GOVERNMENT OFFICE BUILDING'",LOC,,https://das.ohio.gov/Divisions/General-Services/Properties-and-Facilities/Ocasek,FALSE,FALSE,FALSE,TRUE
-train,488,"[822, 826): 'Sask'",LOC,Sentence,"[822, 827): 'Sask.'",LOC,,Incorrect sentence boundary after period and before comma,FALSE,FALSE,TRUE,TRUE
-train,488,"[822, 826): 'Sask'",LOC,Span,"[822, 827): 'Sask.'",,,Period immediately before comma,FALSE,TRUE,FALSE,TRUE
-train,488,"[889, 893): 'Alta'",,Span,"[889, 894): 'Alta.'",,,,FALSE,TRUE,FALSE,TRUE
-train,492,,,Missing,"[283, 288): 'FITCH'",ORG,,Credit rating agency,FALSE,FALSE,FALSE,TRUE
-train,492,,,Missing,"[453, 458): 'FITCH'",ORG,,Credit rating agency,FALSE,FALSE,FALSE,TRUE
-train,523,"[603, 609): 'Rovers'",ORG,Sentence,"[595, 609): 'Bristol Rovers'",,,"Sentence boundary between ""Bristol"" and ""Rovers""",FALSE,FALSE,TRUE,TRUE
-train,523,"[595, 602): 'Bristol'",ORG,Sentence,"[595, 609): 'Bristol Rovers'",ORG,,"Sentence boundary between ""Bristol"" and ""Rovers""",FALSE,TRUE,TRUE,TRUE
-train,524,"[1095, 1103): 'Pakistan'",LOC,Tag,"[1095, 1103): 'Pakistan'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-train,524,"[163, 170): 'England'",LOC,Tag,"[163, 170): 'England'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-train,524,"[20, 27): 'ENGLAND'",LOC,Tag,"[20, 27): 'ENGLAND'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-train,524,"[32, 40): 'PAKISTAN'",LOC,Tag,"[32, 40): 'PAKISTAN'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-train,524,"[74, 81): 'England'",LOC,Tag,"[74, 81): 'England'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-train,524,"[86, 94): 'Pakistan'",LOC,Tag,"[86, 94): 'Pakistan'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-train,527,"[108, 117): 'Kong Open'",MISC,Sentence,"[103, 117): 'Hong Kong Open'",MISC,,"Sentence boundary between ""Hong"" and ""Kong""",FALSE,FALSE,TRUE,TRUE
-train,528,,,Missing,"[1768, 1783): 'fellow-American'",MISC,,,FALSE,TRUE,TRUE,TRUE
-train,528,"[591, 595): 'U.S.'",LOC,Both,"[591, 601): 'U.S. Opens'",MISC,,Multiple instances of the U.S. Open tennis tournament,FALSE,TRUE,FALSE,TRUE
-train,529,"[2369, 2374): 'Czech'",LOC,Sentence,"[2369, 2383): 'Czech Republic'",LOC,,"Sentence boundary between ""Czech"" and ""Republic""",FALSE,TRUE,TRUE,TRUE
-train,529,"[2431, 2439): 'Kleinova'",PER,Sentence,"[2424, 2439): 'Sandra Kleinova'",PER,,Sentence boundary between first and last name,FALSE,FALSE,TRUE,TRUE
-train,529,"[2424, 2430): 'Sandra'",PER,Sentence,"[2424, 2439): 'Sandra Kleinova'",,,Sentence boundary between first and last name,FALSE,TRUE,FALSE,TRUE
-train,530,"[1255, 1268): 'SAN FRANCISCO'",LOC,Tag,"[1255, 1268): 'SAN FRANCISCO'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,530,"[1284, 1292): 'MONTREAL'",LOC,Tag,"[1284, 1292): 'MONTREAL'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,530,"[1304, 1314): 'PITTSBURGH'",LOC,Tag,"[1304, 1314): 'PITTSBURGH'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,530,"[1328, 1336): 'NEW YORK'",LOC,Tag,"[1328, 1336): 'NEW YORK'",ORG,,Baseball team,FALSE,TRUE,TRUE,TRUE
-train,530,"[1348, 1355): 'HOUSTON'",LOC,Tag,"[1348, 1355): 'HOUSTON'",ORG,,Baseball team,FALSE,TRUE,TRUE,TRUE
-train,530,"[1367, 1375): 'ST LOUIS'",LOC,Tag,"[1367, 1375): 'ST LOUIS'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,530,"[1390, 1398): 'COLORADO'",LOC,Tag,"[1390, 1398): 'COLORADO'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,530,"[664, 671): 'DETROIT'",LOC,Tag,"[664, 671): 'DETROIT'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,530,"[683, 692): 'BALTIMORE'",LOC,Tag,"[683, 692): 'BALTIMORE'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,530,"[706, 713): 'TORONTO'",LOC,Tag,"[706, 713): 'TORONTO'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,530,"[727, 734): 'CHICAGO'",LOC,Tag,"[727, 734): 'CHICAGO'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,530,"[744, 755): 'KANSAS CITY'",LOC,Tag,"[744, 755): 'KANSAS CITY'",ORG,,Baseball team,FALSE,TRUE,TRUE,TRUE
-train,530,"[766, 776): 'CALIFORNIA'",LOC,Tag,"[766, 776): 'CALIFORNIA'",ORG,,Baseball team,FALSE,TRUE,TRUE,TRUE
-train,530,"[789, 796): 'SEATTLE'",LOC,Tag,"[789, 796): 'SEATTLE'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,530,"[228, 244): 'EASTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-train,530,"[368, 384): 'CENTRAL DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-train,530,"[510, 526): 'WESTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-train,530,"[813, 829): 'EASTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-train,530,"[960, 976): 'CENTRAL DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-train,530,"[1091, 1107): 'WESTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-train,534,"[1234, 1244): 'Washington'",LOC,Tag,"[1234, 1244): 'Washington'",PER,,Reference to a tennis player whose last name is Washington,FALSE,TRUE,TRUE,TRUE
-train,545,"[476, 479): 'Aki'",PER,Tag,"[476, 479): 'Aki'",ORG,,"Cycling team; correctly tagged ORG at [805, 808): 'Aki'",FALSE,FALSE,TRUE,TRUE
-train,551,"[517, 522): 'Villa'",PER,Tag,"[517, 522): 'Villa'",ORG,,,FALSE,TRUE,TRUE,TRUE
-train,566,,,Missing,"[47, 59): 'Commandments'",MISC,,"[239, 255): 'Ten Commandments' annotated as MISC in first sentence of article",FALSE,FALSE,TRUE,TRUE
-train,566,,,Missing,"[881, 887): 'Church'",ORG,,Catholic Church,FALSE,FALSE,FALSE,TRUE
-train,573,"[701, 712): 'Juan Carlos'",PER,Span,"[701, 720): 'Juan Carlos Ongania'",,,,FALSE,FALSE,TRUE,TRUE
-train,579,,,Missing,"[734, 737): 'U.N'",ORG,,,FALSE,FALSE,TRUE,TRUE
-train,579,"[15, 19): 'U.N.'",ORG,Span,"[734, 737): 'U.N'",,,"Instances of ""U.N."" elsewhere in the same document include final period",FALSE,TRUE,FALSE,TRUE
-train,582,"[1158, 1164): 'Spring'",LOC,Wrong,,,,"Spring wheat, a type of wheat",FALSE,FALSE,FALSE,TRUE
-train,583,"[35, 38): 'Ala'",LOC,Span,"[35, 39): 'Ala.'",,,Comma immediately after period indicates period part of the abbreviation,FALSE,TRUE,FALSE,TRUE
-train,583,"[35, 38): 'Ala'",LOC,Sentence,"[35, 39): 'Ala.'",LOC,,Sentence boundary between period and comma,FALSE,FALSE,TRUE,TRUE
-train,590,"[78, 99): 'Robert W. Baird & Co.'",ORG,Sentence,"[78, 106): 'Robert W. Baird & Co. , Inc.'",,,"Sentence boundary between ""Co."" and "",""",FALSE,TRUE,FALSE,TRUE
-train,590,"[100, 106): ', Inc.'",ORG,Sentence,"[78, 106): 'Robert W. Baird & Co. , Inc.'",ORG,,Sentence boundary between period and comma,FALSE,FALSE,TRUE,TRUE
-train,593,"[45, 57): 'France-Juppe'",MISC,Token,"[45, 51): 'France'",LOC,,"Tokenizer treated ""France-Juppe"" as a single token",FALSE,FALSE,TRUE,TRUE
-train,593,"[45, 57): 'France-Juppe'",MISC,Token,"[52, 57): 'Juppe'",PER,,"Tokenizer treated ""France-Juppe"" as a single token",FALSE,FALSE,TRUE,TRUE
-train,594,"[1236, 1246): 'Eurotunnel'",LOC,Tag,"[1236, 1246): 'Eurotunnel'",ORG,,"Reference to company that operates the tunnel: ""active Eurotunnel was unchanged on nearly a million shares traded.""",FALSE,TRUE,TRUE,TRUE
-train,595,,,Missing,"[1148, 1165): 'Cultural Ministry'",ORG,,,FALSE,TRUE,FALSE,TRUE
-train,601,"[821, 830): 'Bhavnagar'",ORG,Tag,"[821, 830): 'Bhavnagar'",LOC,,"""3,800-3,825 rupees FOR Bhavnagar"", meaning ""3800 rupees per ton delivered to the city of Bhavnagar""",FALSE,TRUE,FALSE,TRUE
-train,608,,,Missing,"[517, 524): 'Hanover'",LOC,,,FALSE,TRUE,TRUE,TRUE
-train,609,"[135, 143): 'Sudanese'",MISC,Span,"[135, 151): 'Sudanese Airways'",,,,FALSE,FALSE,TRUE,TRUE
-train,611,"[37, 42): 'Power'",ORG,Span,"[37, 52): 'Power Financial'",,,Power Financial Corp,FALSE,TRUE,TRUE,TRUE
-train,623,"[238, 250): 'North Island'",PER,Tag,"[238, 250): 'North Island'",MISC,,,FALSE,FALSE,TRUE,TRUE
-train,626,"[42, 59): 'disarmament-China'",MISC,Token,"[42, 59): 'disarmament-China'",,,disarmament-China' treated as a single token,FALSE,TRUE,FALSE,TRUE
-train,637,"[1048, 1055): 'Harwood'",PER,Sentence,"[1043, 1055): 'Mike Harwood'",PER,,Sentence boundary between first and last name,FALSE,FALSE,TRUE,TRUE
-train,637,"[1043, 1047): 'Mike'",PER,Sentence,"[1043, 1055): 'Mike Harwood'",,,Sentence boundary between first and last name,FALSE,TRUE,FALSE,TRUE
-train,637,"[1106, 1116): 'Teravainen'",PER,Sentence,"[1100, 1116): 'Peter Teravainen'",PER,,Sentence boundary between first and last name,FALSE,FALSE,TRUE,TRUE
-train,637,"[1100, 1105): 'Peter'",PER,Sentence,"[1100, 1116): 'Peter Teravainen'",,,Sentence boundary between first and last name,FALSE,TRUE,FALSE,TRUE
-train,637,"[785, 793): 'Chistian'",PER,Sentence,"[785, 800): 'Chistian Cevaer'",,,Sentence boundary between first and last name,FALSE,TRUE,FALSE,TRUE
-train,637,"[794, 800): 'Cevaer'",PER,Sentence,"[785, 800): 'Chistian Cevaer'",PER,,Sentence boundary between first and last name,FALSE,FALSE,TRUE,TRUE
-train,640,"[573, 576): 'Aki'",PER,Tag,"[573, 576): 'Aki'",ORG,,Cycling team,FALSE,FALSE,TRUE,TRUE
-train,640,"[869, 872): 'Aki'",PER,Tag,"[869, 872): 'Aki'",ORG,,Cycling team,FALSE,FALSE,FALSE,TRUE
-train,657,"[103, 112): 'Kong Open'",MISC,Sentence,"[98, 112): 'Hong Kong Open'",MISC,,"Sentence boundary between ""Hong"" and ""Kong""",FALSE,FALSE,TRUE,TRUE
-train,659,"[267, 286): 'Hapoel Ironi Rishon'",ORG,Span,"[267, 293): 'Hapoel Ironi Rishon Lezion'",,,,FALSE,FALSE,TRUE,TRUE
-train,659,"[416, 424): 'Tel Aviv'",ORG,Span,"[408, 424): 'Maccabi Tel Aviv'",,,,FALSE,TRUE,TRUE,TRUE
-train,663,"[1262, 1270): 'COLORADO'",LOC,Tag,"[1262, 1270): 'COLORADO'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,663,"[1286, 1294): 'MONTREAL'",LOC,Tag,"[1286, 1294): 'MONTREAL'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,663,"[1306, 1316): 'PITTSBURGH'",LOC,Tag,"[1306, 1316): 'PITTSBURGH'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,663,"[1330, 1338): 'NEW YORK'",LOC,Tag,"[1330, 1338): 'NEW YORK'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,663,"[1350, 1357): 'HOUSTON'",LOC,Tag,"[1350, 1357): 'HOUSTON'",ORG,,Baseball team,FALSE,FALSE,TRUE,TRUE
-train,663,"[1369, 1377): 'ST LOUIS'",LOC,Tag,"[1369, 1377): 'ST LOUIS'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,663,"[1394, 1407): 'SAN FRANCISCO'",LOC,Tag,"[1394, 1407): 'SAN FRANCISCO'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,663,"[669, 676): 'DETROIT'",LOC,Tag,"[669, 676): 'DETROIT'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,663,"[690, 697): 'CHICAGO'",LOC,Tag,"[690, 697): 'CHICAGO'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,663,"[709, 718): 'BALTIMORE'",LOC,Tag,"[709, 718): 'BALTIMORE'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,663,"[732, 739): 'TORONTO'",LOC,Tag,"[732, 739): 'TORONTO'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,663,"[749, 760): 'KANSAS CITY'",LOC,Tag,"[749, 760): 'KANSAS CITY'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,663,"[771, 781): 'CALIFORNIA'",LOC,Tag,"[771, 781): 'CALIFORNIA'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,663,"[794, 801): 'SEATTLE'",LOC,Tag,"[794, 801): 'SEATTLE'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,663,"[230, 246): 'EASTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-train,663,"[370, 386): 'CENTRAL DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-train,663,"[513, 529): 'WESTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-train,663,"[818, 834): 'EASTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-train,663,"[965, 981): 'CENTRAL DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-train,663,"[1098, 1114): 'WESTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-train,664,"[82, 94): 'Major League'",MISC,Sentence,"[82, 103): 'Major League Baseball'",MISC,,"Sentence boundary between ""League"" and ""Baseball""",FALSE,TRUE,TRUE,TRUE
-train,668,"[1238, 1246): 'Calderon'",LOC,Span,"[1230, 1246): 'Vicente Calderon'",LOC,,https://en.wikipedia.org/wiki/Vicente_Calder%C3%B3n_Stadium,FALSE,FALSE,FALSE,TRUE
-train,668,"[1230, 1237): 'Vicente'",PER,Wrong,,,,,FALSE,FALSE,FALSE,TRUE
-train,676,"[199, 208): 'Becanovic'",PER,Sentence,"[191, 208): 'Miladin Becanovic'",PER,,Sentence boundary between first and last name,FALSE,FALSE,TRUE,TRUE
-train,676,"[191, 198): 'Miladin'",PER,Sentence,"[191, 208): 'Miladin Becanovic'",,,Sentence boundary between first and last name,FALSE,TRUE,FALSE,TRUE
-train,676,"[377, 382): 'Scifo'",PER,Sentence,"[372, 382): 'Enzo Scifo'",PER,,Sentence boundary between first and last name,FALSE,FALSE,TRUE,TRUE
-train,676,"[372, 376): 'Enzo'",PER,Sentence,"[372, 382): 'Enzo Scifo'",,,Sentence boundary between first and last name,FALSE,TRUE,FALSE,TRUE
-train,678,"[323, 333): 'de Nooijer'",PER,Sentence,"[316, 333): 'Gerard de Nooijer'",PER,,Sentence boundary between first and last name,FALSE,FALSE,TRUE,TRUE
-train,678,"[316, 322): 'Gerard'",PER,Sentence,"[316, 333): 'Gerard de Nooijer'",,,Sentence boundary between first and last name,FALSE,TRUE,FALSE,TRUE
-train,678,"[573, 583): 'Doetinchem'",ORG,Sentence,"[562, 583): 'Graafschap Doetinchem'",ORG,,Sentence boundary between first and second word,FALSE,FALSE,TRUE,TRUE
-train,678,"[562, 572): 'Graafschap'",ORG,Sentence,"[562, 583): 'Graafschap Doetinchem'",,,Sentence boundary between first and second part of name,FALSE,TRUE,FALSE,TRUE
-train,686,"[136, 141): 'India'",LOC,Tag,"[136, 141): 'India'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-train,686,"[146, 155): 'Sri Lanka'",LOC,Tag,"[146, 155): 'Sri Lanka'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-train,686,"[170, 175): 'India'",LOC,Tag,"[170, 175): 'India'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-train,686,"[20, 25): 'INDIA'",LOC,Tag,"[20, 25): 'INDIA'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-train,686,"[28, 37): 'SRI LANKA'",LOC,Tag,"[28, 37): 'SRI LANKA'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-train,686,"[665, 674): 'Sri Lanka'",LOC,Tag,"[665, 674): 'Sri Lanka'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-train,686,"[897, 909): 'Tillekeratne'",PER,Sentence,"[890, 909): 'Hashan Tillekeratne'",PER,,Sentence boundary between first and last name,FALSE,FALSE,TRUE,TRUE
-train,686,"[101, 113): 'World Series'",MISC,Sentence,"[94, 113): 'Singer World Series'",MISC,,"Sentence boundary between ""Singer"" and ""World""",FALSE,FALSE,TRUE,TRUE
-train,686,"[94, 100): 'Singer'",MISC,Sentence,"[94, 113): 'Singer World Series'",,,"Sentence boundary between ""Singer"" and ""World""",FALSE,TRUE,FALSE,TRUE
-train,698,,,Missing,"[1171, 1177): 'Apache'",MISC,,,FALSE,FALSE,TRUE,TRUE
-train,698,"[1994, 2008): 'Crystal Palace'",ORG,Tag,"[1994, 2008): 'Crystal Palace'",LOC,,The world's firstï¿½Boy Scout Rallyï¿½was held atï¿½Crystal Palaceï¿½nearï¿½London.,FALSE,TRUE,FALSE,TRUE
-train,701,"[1072, 1079): 'England'",LOC,Tag,"[1072, 1079): 'England'",ORG,,National rugby team,FALSE,FALSE,FALSE,TRUE
-train,701,"[17, 30): 'union-England'",MISC,Token,"[23, 30): 'England'",ORG,,"English national rugby team: ""Rugbyï¿½union-Englandï¿½given final chance to stay inï¿½Five Nations.""",FALSE,TRUE,TRUE,TRUE
-train,701,"[372, 380): 'Scotland'",LOC,Tag,"[372, 380): 'Scotland'",ORG,,National rugby team,FALSE,FALSE,FALSE,TRUE
-train,701,"[382, 387): 'Wales'",LOC,Tag,"[382, 387): 'Wales'",ORG,,National rugby team,FALSE,FALSE,FALSE,TRUE
-train,701,"[389, 396): 'Ireland'",LOC,Tag,"[389, 396): 'Ireland'",ORG,,National rugby team,FALSE,FALSE,FALSE,TRUE
-train,701,"[401, 407): 'France'",LOC,Tag,"[401, 407): 'France'",ORG,,National rugby team,FALSE,FALSE,FALSE,TRUE
-train,701,"[659, 666): 'England'",LOC,Tag,"[659, 666): 'England'",ORG,,National rugby team,FALSE,FALSE,FALSE,TRUE
-train,701,"[93, 100): 'England'",LOC,Tag,"[93, 100): 'England'",ORG,,"English national rugby team: ""Englandï¿½have been given a final chance to remain in theï¿½Five Nationsï¿½' championshipï¿½""",FALSE,FALSE,FALSE,TRUE
-train,713,,,Missing,"[2362, 2370): 'Belgians'",MISC,,,FALSE,FALSE,TRUE,TRUE
-train,724,,,Missing,"[1233, 1243): 'U.S.-bound'",MISC,,,FALSE,FALSE,TRUE,TRUE
-train,724,"[1299, 1308): 'Salamanca'",LOC,Tag,"[1299, 1308): 'Salamanca'",PER,,,FALSE,FALSE,FALSE,TRUE
-train,724,"[395, 401): 'Adolfo'",PER,Span,"[395, 411): 'Adolfo Salamanca'",PER,,,FALSE,FALSE,FALSE,TRUE
-train,724,"[402, 411): 'Salamanca'",LOC,Wrong,,,,,FALSE,FALSE,FALSE,TRUE
-train,725,"[134, 141): 'Richter'",PER,Tag,"[134, 141): 'Richter'",MISC,,"""Richter scale""",FALSE,FALSE,TRUE,TRUE
-train,734,"[45, 48): 'Kan'",LOC,Span,"[45, 49): 'Kan.'",,,Sentence boundary between period and comma confused human labeler,FALSE,TRUE,FALSE,TRUE
-train,734,"[45, 48): 'Kan'",LOC,Sentence,"[45, 49): 'Kan.'",LOC,,Sentence boundary between period and comma,FALSE,FALSE,TRUE,TRUE
-train,734,"[84, 94): 'JOHNSON CO'",ORG,Sentence,"[84, 95): 'JOHNSON CO.'",ORG,,Sentence boundary between period and comma,FALSE,FALSE,FALSE,TRUE
-train,738,"[585, 601): 'Shabwa Block No.'",MISC,Sentence,"[585, 605): 'Shabwa Block No. S-1'",,,,FALSE,TRUE,FALSE,TRUE
-train,739,"[602, 605): 'S-1'",MISC,Sentence,"[585, 605): 'Shabwa Block No. S-1'",MISC,,"Sentence boundary between ""No."" and ""S-1""",FALSE,FALSE,TRUE,TRUE
-train,758,"[263, 266): 'Ark'",LOC,Sentence,"[263, 267): 'Ark.'",LOC,,Sentence boundary between period and comma,FALSE,FALSE,TRUE,TRUE
-train,758,"[263, 266): 'Ark'",LOC,Span,"[263, 267): 'Ark.'",,,Sentence boundary between period and comma confused human labeler,FALSE,TRUE,FALSE,TRUE
-train,778,"[371, 382): 'Maryborough'",PER,Tag,"[371, 382): 'Maryborough'",LOC,,"The shooting occured around 6.30 a.m. (2030ï¿½GMT) on Tuesday atï¿½Glenwood, south ofï¿½Maryborough,ï¿½",FALSE,TRUE,TRUE,TRUE
-train,778,"[63, 71): 'BRISBANE'",ORG,Tag,"[63, 71): 'BRISBANE'",LOC,,Dateline of article,FALSE,TRUE,TRUE,TRUE
-train,780,"[627, 634): 'Son Sen'",LOC,Tag,"[627, 634): 'Son Sen'",PER,,https://en.wikipedia.org/wiki/Son_Sen,FALSE,FALSE,TRUE,TRUE
-train,780,,,Missing,"[64, 77): 'ARANYAPRATHET'",LOC,,,FALSE,TRUE,TRUE,TRUE
-train,794,"[41, 47): 'Iberia'",ORG,Tag,"[41, 47): 'Iberia'",LOC,,Iberian peninsula,FALSE,FALSE,TRUE,TRUE
-train,800,"[1108, 1115): 'Affleck'",PER,Sentence,"[1103, 1115): 'Paul Affleck'",PER,,Sentence boundary between first and last name,FALSE,FALSE,TRUE,TRUE
-train,800,"[1103, 1107): 'Paul'",PER,Sentence,"[1103, 1115): 'Paul Affleck'",,,Sentence boundary between first and last name,FALSE,TRUE,FALSE,TRUE
-train,800,"[483, 488): 'Davis'",PER,Sentence,"[478, 488): 'Mark Davis'",PER,,Sentence boundary between first and last name,FALSE,FALSE,TRUE,TRUE
-train,800,"[478, 482): 'Mark'",PER,Sentence,"[478, 488): 'Mark Davis'",,,Sentence boundary between first and last name,FALSE,TRUE,FALSE,TRUE
-train,800,"[559, 565): 'Goosen'",PER,Sentence,"[552, 565): 'Retief Goosen'",PER,,Sentence boundary between first and last name,FALSE,FALSE,TRUE,TRUE
-train,800,"[552, 558): 'Retief'",PER,Sentence,"[552, 565): 'Retief Goosen'",,,Sentence boundary between first and last name,FALSE,TRUE,FALSE,TRUE
-train,800,"[835, 842): 'Woosnam'",PER,Sentence,"[831, 842): 'Ian Woosnam'",PER,,Sentence boundary between first and last name,FALSE,FALSE,TRUE,TRUE
-train,800,"[831, 834): 'Ian'",PER,Sentence,"[831, 842): 'Ian Woosnam'",,,Sentence boundary between first and last name,FALSE,TRUE,FALSE,TRUE
-train,800,"[891, 899): 'Eriksson'",PER,Sentence,"[886, 899): 'Klas Eriksson'",PER,,Sentence boundary between first and last name,FALSE,FALSE,TRUE,TRUE
-train,800,"[886, 890): 'Klas'",PER,Sentence,"[886, 899): 'Klas Eriksson'",,,Sentence boundary between first and last name,FALSE,TRUE,FALSE,TRUE
-train,800,"[993, 1000): 'Coltart'",PER,Sentence,"[986, 1000): 'Andrew Coltart'",PER,,Sentence boundary between first and last name,FALSE,FALSE,TRUE,TRUE
-train,800,"[986, 992): 'Andrew'",PER,Sentence,"[986, 1000): 'Andrew Coltart'",,,Sentence boundary between first and last name,FALSE,TRUE,FALSE,TRUE
-train,803,"[794, 806): 'Vasilopoulos'",PER,Sentence,"[786, 806): 'Lampros Vasilopoulos'",PER,,Sentence boundary between first and last name,FALSE,FALSE,TRUE,TRUE
-train,803,"[786, 793): 'Lampros'",PER,Sentence,"[786, 806): 'Lampros Vasilopoulos'",,,Sentence boundary between first and last name,FALSE,TRUE,FALSE,TRUE
-train,808,"[20, 47): 'ENGLISH COUNTY CHAMPIONSHIP'",MISC,Span,"[20, 27): 'ENGLISH'",MISC,,The County Championship is an event held in England,FALSE,FALSE,FALSE,TRUE
-train,808,"[20, 47): 'ENGLISH COUNTY CHAMPIONSHIP'",MISC,Span,"[28, 47): COUNTY CHAMPIONSHIP'",MISC,,The County Championship is an event held in England,FALSE,FALSE,FALSE,TRUE
-train,817,"[1207, 1215): 'NEW YORK'",LOC,Tag,"[1207, 1215): 'NEW YORK'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,817,"[1227, 1234): 'HOUSTON'",LOC,Tag,"[1227, 1234): 'HOUSTON'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,817,"[1249, 1257): 'COLORADO'",LOC,Tag,"[1249, 1257): 'COLORADO'",ORG,,Baseball team,FALSE,FALSE,TRUE,TRUE
-train,817,"[1269, 1279): 'PITTSBURGH'",LOC,Tag,"[1269, 1279): 'PITTSBURGH'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,817,"[1295, 1303): 'MONTREAL'",LOC,Tag,"[1295, 1303): 'MONTREAL'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,817,"[1315, 1323): 'ST LOUIS'",LOC,Tag,"[1315, 1323): 'ST LOUIS'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,817,"[674, 681): 'DETROIT'",LOC,Tag,"[674, 681): 'DETROIT'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,817,"[695, 704): 'MILWAUKEE'",LOC,Tag,"[695, 704): 'MILWAUKEE'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,817,"[717, 727): 'CALIFORNIA'",LOC,Tag,"[717, 727): 'CALIFORNIA'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,817,"[741, 748): 'SEATTLE'",LOC,Tag,"[741, 748): 'SEATTLE'",ORG,,Baseball team,FALSE,FALSE,FALSE,TRUE
-train,817,"[234, 250): 'EASTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-train,817,"[374, 390): 'CENTRAL DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-train,817,"[517, 533): 'WESTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-train,817,"[765, 781): 'EASTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-train,817,"[1045, 1061): 'WESTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,FALSE,FALSE,FALSE,TRUE
-train,819,"[84, 96): 'Major League'",MISC,Sentence,"[84, 105): 'Major League Baseball'",,,"Sentence boundary between ""League"" and ""Baseball""",FALSE,TRUE,FALSE,TRUE
-train,821,"[690, 697): 'Atlanta'",LOC,Tag,"[690, 697): 'Atlanta'",ORG,,Atlanta Braves,FALSE,FALSE,TRUE,TRUE
-train,832,"[419, 427): 'EUROLIRA'",ORG,Tag,"[419, 427): 'EUROLIRA'",MISC,,,FALSE,TRUE,TRUE,TRUE
-train,832,"[452, 461): 'EUROSWISS'",ORG,Tag,"[452, 461): 'EUROSWISS'",MISC,,,FALSE,TRUE,TRUE,TRUE
-train,871,"[193, 204): 'MS-NBC News'",MISC,Tag,"[193, 204): 'MS-NBC News'",ORG,,,FALSE,TRUE,TRUE,TRUE
-train,872,"[221, 239): 'CHICAGO AREA MILLS'",MISC,Both,"[221, 228): 'CHICAGO'",LOC,,,FALSE,TRUE,TRUE,TRUE
-train,872,"[382, 389): 'DECATUR'",ORG,Tag,"[382, 389): 'DECATUR'",LOC,,,FALSE,FALSE,FALSE,TRUE
-train,872,"[395, 419): 'CLINTON AND CEDAR RAPIDS'",ORG,Both,"[395, 402): 'CLINTON'",LOC,,,FALSE,FALSE,FALSE,TRUE
-train,872,"[395, 419): 'CLINTON AND CEDAR RAPIDS'",ORG,Tag,"[395, 419): 'CLINTON AND CEDAR RAPIDS'",LOC,,Two cities in Iowa,FALSE,FALSE,FALSE,TRUE
-train,872,"[395, 419): 'CLINTON AND CEDAR RAPIDS'",ORG,Both,"[407, 419): 'CEDAR RAPIDS'",LOC,,,FALSE,FALSE,FALSE,TRUE
-train,874,"[59, 65): 'RENNES'",ORG,Tag,"[59, 65): 'RENNES'",LOC,,,FALSE,TRUE,TRUE,TRUE
-train,893,"[124, 130): 'Fowler'",PER,Span,"[118, 130): 'Wyche Fowler'",,,,FALSE,FALSE,TRUE,TRUE
-train,893,"[124, 130): 'Fowler'",,Span,"[118, 130): 'Wyche Fowler'",ORG,,,FALSE,TRUE,FALSE,TRUE
-train,918,"[11, 24): 'INTERVIEW-T&N'",,Token,"[11, 24): 'INTERVIEW-T&N'",,,INTERVIEW-T&N' treated as a single token,FALSE,TRUE,FALSE,TRUE
-train,918,"[11, 24): 'INTERVIEW-T&N'",MISC,Token,"[21, 24): 'T&N'",ORG,,"Tokenizer treated ""INVERVIEW-T&N"" as a single token",FALSE,FALSE,TRUE,TRUE
-train,919,"[112, 119): 'Richter'",PER,Tag,"[112, 119): 'Richter'",MISC,,,FALSE,FALSE,TRUE,TRUE
-train,930,"[706, 707): '3'",ORG,Sentence,"[698, 707): 'CDU No. 3'",ORG,,"Sentence boundary between ""No."" and ""3""",FALSE,FALSE,TRUE,TRUE
-train,930,"[698, 705): 'CDU No.'",ORG,Sentence,"[698, 707): 'CDU No. 3'",,,"Sentence boundary between ""No."" and 3",FALSE,TRUE,FALSE,TRUE
-train,937,"[1649, 1652): 'Inc'",ORG,Sentence,"[1626, 1652): 'Goldman, Sachs and Co. Inc'",ORG,,"Sentence boundary between ""Co."" and ""Inc.""",FALSE,FALSE,TRUE,TRUE
-train,937,"[1626, 1648): 'Goldman, Sachs and Co.'",ORG,Sentence,"[1626, 1652): 'Goldman, Sachs and Co. Inc'",,,"Sentence boundary between ""Co."" and ""Inc""",FALSE,TRUE,FALSE,TRUE
-train,944,"[1036, 1042): 'Africa'",LOC,Sentence,"[1030, 1042): 'South Africa'",LOC,,"Sentence boundary between ""South"" and ""Africa""",FALSE,FALSE,TRUE,TRUE
-train,944,"[1030, 1035): 'South'",LOC,Sentence,"[1030, 1042): 'South Africa'",,,"Sentence boundary between ""South"" and ""Africa""",FALSE,TRUE,FALSE,TRUE
-train,944,"[415, 420): 'South'",LOC,Sentence,"[415, 427): 'South Africa'",LOC,,"Sentence boundary between ""South"" and ""Africa""",FALSE,FALSE,TRUE,TRUE
-,163,"[411, 424): 'Conservatives'  ",,Missing,,ORG,,political party,FALSE,FALSE,FALSE,TRUE
-,176,"[2419, 2425): 'Busang'  ",ORG,Tag,"[2419, 2425): 'Busang'  ",LOC,,??? city in Indonesia that has big gold deposits,FALSE,FALSE,FALSE,TRUE
-,176,"[2732, 2738): 'Busang'",ORG,Tag,"[2732, 2738): 'Busang'",LOC,,,FALSE,FALSE,FALSE,TRUE
-,,"[143, 151): 'Tasmania'",LOC,Tag,"[143, 151): 'Tasmania'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-,,"[156, 164): 'Victoria'",LOC,Tag,"[156, 164): 'Victoria'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-,,"[267, 286): 'Hapoel Ironi Rishon'",ORG,Span,"[267, 293): 'Hapoel Ironi Rishon Lezion'",,,,FALSE,FALSE,FALSE,TRUE
-,,,,Missing,"[410, 427): 'VERN RIFFE CENTER'",LOC,,https://vrcfa.com/,FALSE,FALSE,FALSE,TRUE
-,,"[419, 427): 'EUROLIRA'",ORG,Tag,"[419, 427): 'EUROLIRA'",MISC,,Reference to futures contracts on Euro/Lira exchange rate,FALSE,FALSE,FALSE,TRUE
-,,"[732, 740): 'Pakistan'",LOC,Tag,"[732, 740): 'Pakistan'",ORG,,Cricket team,FALSE,FALSE,FALSE,TRUE
-,,"[84, 94): 'JOHNSON CO'",ORG,Span,"[84, 95): 'JOHNSON CO.'",,,Sentence boundary between period and comma confused human labeler,FALSE,FALSE,FALSE,TRUE
-,,,,Missing,"[854, 874): 'Overseas Development'",ORG,,Reference to Britain's Overseas Development Administration,FALSE,FALSE,FALSE,TRUE
-,,"[2264, 2267): 'RBI'",MISC,Wrong,,,,Run batted in,FALSE,FALSE,FALSE,TRUE
+dev,2,"[122, 129): 'England'",LOC,Tag,"[122, 129): 'England'",ORG,,Cricket team,False,False,False,True
+dev,2,"[1354, 1362): 'Scotland'",LOC,Tag,"[1354, 1362): 'Scotland'",ORG,,,False,False,False,True
+dev,2,"[235, 244): 'Australia'",LOC,Tag,"[235, 244): 'Australia'",ORG,,Cricket team,False,False,False,True
+dev,2,"[525, 533): 'Scotland'",LOC,Tag,"[525, 533): 'Scotland'",ORG,,Cricket team,False,False,False,True
+dev,2,"[61, 70): 'Australia'",LOC,Tag,"[61, 70): 'Australia'",ORG,,Cricket team,False,False,False,True
+dev,2,"[760, 765): 'Leeds'",ORG,Tag,"[760, 765): 'Leeds'",LOC,,,False,True,True,True
+dev,6,"[47, 56): 'VOLGOGRAD'",LOC,Tag,"[47, 56): 'VOLGOGRAD'",ORG,16,,False,True,False,False
+dev,7,"[1004, 1022): 'Boxing Association'",ORG,Span,"[993, 1022): 'Panamanian Boxing Association'",ORG,,,False,False,True,True
+dev,11,"[1967, 1975): 'Republic'",LOC,Sentence,"[1961, 1975): 'Czech Republic'",,,"Sentence boundary between ""Czech"" and ""Republic""",False,False,True,True
+dev,11,"[1961, 1966): 'Czech'",LOC,Sentence,,,17,,False,True,False,False
+dev,12,"[1247, 1254): 'CHICAGO'",LOC,Tag,"[1247, 1254): 'CHICAGO'",ORG,13,Team,False,True,False,False
+dev,12,"[1266, 1276): 'CINCINNATI'",LOC,Tag,"[1266, 1276): 'CINCINNATI'",ORG,17,Sports team ,False,True,False,False
+dev,12,"[1290, 1298): 'MONTREAL'",LOC,Tag,"[1290, 1298): 'MONTREAL'",ORG,17,sports team,False,True,False,False
+dev,12,"[1314, 1326): 'PHILADELPHIA'",LOC,Tag,"[1314, 1326): 'PHILADELPHIA'",ORG,,Baseball team,False,True,True,True
+dev,12,"[1338, 1348): 'PITTSBURGH'",LOC,Tag,"[1338, 1348): 'PITTSBURGH'",ORG,15,baseball team ,False,True,False,False
+dev,12,"[1366, 1374): 'NEW YORK'",LOC,Tag,"[1366, 1374): 'NEW YORK'",ORG,16,baseball team ,False,True,False,False
+dev,12,"[1387, 1395): 'ST LOUIS'",LOC,Tag,"[1387, 1395): 'ST LOUIS'",ORG,,Home team for a baseball game,False,False,False,True
+dev,12,"[672, 679): 'DETROIT'",LOC,Tag,"[672, 679): 'DETROIT'",ORG,,Home team for a baseball game,False,False,False,True
+dev,12,"[691, 698): 'TORONTO'",LOC,Tag,"[691, 698): 'TORONTO'",ORG,14,baseball team ,False,True,False,False
+dev,12,"[712, 721): 'MILWAUKEE'",LOC,Tag,"[712, 721): 'MILWAUKEE'",ORG,,Home team for a baseball game,False,False,False,True
+dev,12,"[735, 740): 'TEXAS'",LOC,Tag,"[735, 740): 'TEXAS'",ORG,14,baseball team ,False,True,False,False
+dev,12,"[753, 763): 'CALIFORNIA'",LOC,Tag,"[753, 763): 'CALIFORNIA'",ORG,,Home team for a baseball game,False,False,False,True
+dev,12,"[774, 781): 'OAKLAND'",LOC,Tag,"[774, 781): 'OAKLAND'",ORG,,Home team for a baseball game,False,False,False,True
+dev,12,"[795, 802): 'SEATTLE'",LOC,Tag,"[795, 802): 'SEATTLE'",ORG,17,Sports team,False,True,False,False
+dev,12,"[88, 109): 'Major League Baseball'",MISC,Tag,"[88, 109): 'Major League Baseball'",ORG,14,organization ,False,True,False,False
+dev,12,"[232, 248): 'EASTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+dev,12,"[380, 396): 'CENTRAL DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+dev,12,"[519, 535): 'WESTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+dev,12,"[819, 835): 'EASTERN DIVISION",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+dev,12,"[962, 978): 'CENTRAL DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+dev,12,"[1095, 1111): 'WESTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+dev,12,"[819, 835): 'EASTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+dev,13,"[83, 95): 'Major League'",MISC,Sentence,"[83, 104): 'Major League Baseball'",,,"Sentence boundary between ""League"" and ""Baseball""",False,True,True,True
+dev,14,,,Missing,"[452, 459): 'Stadium'",LOC,,"""Stadium"" with a capital ""S"", referring to Arthur Ashe Stadium",False,True,True,True
+dev,15,"[41, 51): 'CUNNINGHAM'",PER,Token,"(33, 51]: 'RANDALL CUNNINGHAM'",,,"need to split on '-' ""FOOTBALL-RANDALL""",False,False,False,True
+dev,15,"[41, 51): 'CUNNINGHAM'",PER,Token,"(33,51] 'RANDALL CUNNINGHAM'",,14,,False,True,False,False
+dev,15,"[15, 40): 'AMERICAN FOOTBALL-RANDALL'",MISC,Token,"[33, 40): 'RANDALL'",PER,,"""FOOTBALL-RANDALL"" treated as a single token",False,False,True,True
+dev,15,"[41, 51): 'CUNNINGHAM'",PER,Token,"[33,51): 'RANDALL CUNNINGHAM'",MISC,,"Tokenizer treated ""FOOTBALL-RANDALL"" as a single token",False,False,False,True
+dev,15,"[15, 40): 'AMERICAN FOOTBALL-RANDALL'",MISC,Wrong,,,16, divisions of leagues not entities,True,False,False,False
+dev,16,"[414, 418): 'Wood'",PER,Sentence,"[407, 418): 'Willie Wood'",,17,,False,True,False,False
+dev,16,"[533, 538): 'Green'",PER,Sentence,"[529, 538): 'Ken Green'",,17,,False,True,False,False
+dev,20,"[5423, 5433): 'Fredericks'",PER,Sentence,"[5415, 5433): 'Frankie Fredericks'",,,Sentence boundary between first and last name,False,False,True,True
+dev,20,"[5423, 5433): 'Fredericks'",PER,Sentence,"[5415, 5433): 'Frankie Fredricks'",,17,,False,True,False,False
+dev,20,"[5650, 5665): 'Panayiotopoulos'",PER,Sentence,"[5643, 5665): 'George Panayiotopoulos'",,17,,False,True,False,False
+dev,20,"[90, 96): 'Berlin'",MISC,Sentence,"[90, 107): 'Berlin Grand Prix'",,16,,True,False,False,False
+dev,26,"[1381, 1386): 'India'",LOC,Tag,"[1381, 1386): 'India'",ORG,,Cricket team,False,False,False,True
+dev,26,"[1389, 1397): 'Zimbabwe'",LOC,Tag,"[1389, 1397): 'Zimbabwe'",ORG,,Cricket team,False,False,False,True
+dev,26,"[139, 148): 'Australia'",LOC,Tag,"[139, 148): 'Australia'",ORG,,Cricket team,False,False,False,True
+dev,26,"[153, 162): 'Sri Lanka'",LOC,Tag,"[153, 162): 'Sri Lanka'",ORG,,Cricket team,False,False,False,True
+dev,26,"[174, 183): 'Australia'",LOC,Tag,"[174, 183): 'Australia'",ORG,17,Cricket team,False,True,False,False
+dev,26,"[20, 29): 'AUSTRALIA'",LOC,Tag,"[20, 29): 'AUSTRALIA'",ORG,,Cricket team,False,False,False,True
+dev,26,"[32, 41): 'SRI LANKA'",LOC,Tag,"[32, 41): 'SRI LANKA'",ORG,,Cricket team,False,False,False,True
+dev,26,"[97, 103): 'Singer'",MISC,Sentence,"[97, 116): 'Singer World Series'",,17,,False,True,False,False
+dev,28,"[20, 29): 'AUSTRALIA'",LOC,Tag,"[20, 29): 'AUSTRALIA'",ORG,,Cricket team,False,False,False,True
+dev,28,"[244, 253): 'Australia'",LOC,Tag,"[244, 253): 'Australia'",ORG,,Cricket team,False,False,False,True
+dev,28,"[291, 297): 'Damien'",PER,Sentence,"[291, 306): 'Damien Flemming'",,17,,False,True,False,False
+dev,28,"[358, 365): 'Ponting'",PER,Sentence,"[352, 365): 'Ricky Ponting'",,17,,False,True,False,False
+dev,28,"[411, 416): 'Steve'",PER,Sentence,"[411, 422): 'Steve Waugh'",,17,,False,True,False,False
+dev,28,"[77, 86): 'Australia'",LOC,Tag,"[77, 86): 'Australia'",ORG,,Cricket team,False,False,False,True
+dev,30,,,Missing,"[18, 21): 'NBP'",ORG,,NBP == National Bank of Poland,False,False,False,True
+dev,33,,,Missing,"[11, 16): 'NYMEX'",ORG,,NYMEX heating oil near session lows in pre-close.,False,True,False,True
+dev,33,,,Missing,"[1186, 1191): 'NYMEX'",ORG,,New York Mercantile Exchange,False,True,True,True
+dev,33,,,Missing,"[81, 86): 'NYMEX'",MISC,,"New York Mercantile Exchange, used as an adjective",False,False,False,True
+dev,35,"[70, 74): 'Mich'",LOC,Span,"[70, 75): 'Mich.'",,,Period on abbreviation at end of dateline,False,False,True,True
+dev,38,,,Missing,"[1011, 1016): 'MATIF'",ORG,,,True,True,True,True
+dev,38,,,Missing,"[735, 738): 'PMI'",MISC,,the PMI survey,False,False,True,True
+dev,38,"[2202, 2211): 'EUROBONDS'",MISC,Wrong,,,16,"Zach: Bond exchange market; Fred: ""Eurobond"" appears to be a generic term for a type of bond; see https://www.investopedia.com/terms/e/eurobond.asp",False,True,False,False
+dev,39,"[11, 23): 'Boxing-Bruno'",MISC,Token,"[18, 23): 'Bruno'",PER,17,,False,True,True,False
+dev,39,,MISC,Token,"[18, 23): 'Bruno'	",PER,,"Tokenizer treats ""Boxing-Bruno"" as one token",False,True,False,True
+dev,42,"[476, 539): 'Driefontein Consolidated and Gold Fields ' Kloof Gold Mining Co'",ORG,Span,"[476, 500): 'Driefontein Consolidated'",ORG,17,,True,True,True,False
+dev,42,,,Missing,"[505, 516): 'Gold Fields'",ORG,16,Description of two companies jointly owning a third company,True,False,False,False
+dev,42,,,Missing,"[519, 539): 'Kloof Gold Mining Co'",ORG,16,Description of two companies jointly owning a third company,True,False,False,False
+dev,59,,,Missing,"[2024, 2029): 'Comex'",MISC,,"""New York's Comex market""",False,False,True,True
+dev,60,"[1358, 1371): 'Tripoli-based'",MISC,Token,"[1358, 1365): 'Tripoli'",LOC,15,,False,True,False,False
+dev,61,"[3878, 3888): 'Whitewater'",LOC,Tag,"[3878, 3888): 'Whitewater'",MISC,16,Event: whitewater scandal,False,True,False,False
+dev,61,"[4515, 4524): 'Dow Jones'",MISC,Tag,"[4515, 4524): 'Dow Jones'",ORG,,Fred: See previous line,False,False,False,True
+dev,61,"[4614, 4620): 'Nasdaq'",MISC,Tag,"[4614, 4620): 'Nasdaq'",ORG,13,"Zach: CHECK: should this be ORG? ; Fred: Ambiguous, but there are four examples back-to-back, two tagged one way and two the other. Making everything ORG.",False,True,False,False
+dev,62,"[2553, 2564): 'First Union'",ORG,Span,"[2553, 2569): 'First Union bank'",ORG,17,,False,True,False,False
+dev,64,"[2571, 2575): 'AIDS'",MISC,Wrong,,,15,"Name of a disease, but disease idt counts ",False,True,False,False
+dev,65,"[1135, 1140): 'Louis'",MISC,Sentence,"(1130, 1140]: 'St. Louis'",LOC,16,Sentence boundary btw St. and Louis,True,False,False,False
+dev,65,"[1125, 1134): 'asset-St.'",MISC,Sentence,"[1131, 1140): 'St. Louis'",LOC,,Sentence boundary AND token problem,False,False,True,True
+dev,65,"[1125, 1134): 'asset-St.'",MISC,Token,"[1131, 1146): 'St. Louis based'",MISC,8,"[1125, 1133): 'asset-St' treated as a single token",True,False,False,False
+dev,65,"[1135, 1140): 'Louis'",MISC,Sentence,"[1131,1140) 'St. Louis' ",,17,,False,True,False,False
+dev,65,"[1125, 1134): 'asset-St.'",MISC,Sentence,"[1131,1140) 'St. Louis' ",LOC,17,Sentence and token. Should be 'asset-' 'st' '.' 'louis'  AND sentence break btween st and louis.  Also need to double check my span. ,False,True,False,False
+dev,65,"[592, 607): 'St. Louis-based'",MISC,Token,"[592, 601): 'St. Louis'",LOC,15,,False,True,False,False
+dev,65,"[1125, 1134): 'asset-St.'",MISC,Token,,,16,Asset-St. Treated as 1 token,True,False,False,False
+dev,77,"[14, 34): 'Computer Systems Inc'",ORG,Span,"[11, 34): 'Aw Computer Systems Inc'",ORG,16,,False,True,False,False
+dev,77,"[14, 34): 'Computer Systems Inc'",,Span,"[11, 34): 'Aw Computer Systems Inc'",,,,False,True,False,True
+dev,78,"[81, 85): 'Name'",MISC,Wrong,,,17,,True,True,True,False
+dev,80,"[716, 722): 'Gama'a'",MISC,Tag,"[716, 722): 'Gama'a'",ORG,17,,False,True,False,False
+dev,83,,,Missing,"[1718, 1726): 'Commerce'",ORG,9,,True,False,False,False
+dev,84,"[114, 120): 'NY Dow'",MISC,Tag,"[114, 120): 'NY Dow'",ORG,16,Fred: Stock market,False,True,False,False
+dev,84,"[1274, 1287): 'Raymond James'",PER,Tag,"[1274, 1287): 'Raymond James'",ORG,17,,False,True,False,False
+dev,84,"[195, 201): 'Nikkei'",MISC,Tag,"[195, 201): 'Nikkei'",ORG,,Fred: Stock market,False,False,False,True
+dev,84,"[273, 277): 'FTSE'",MISC,Tag,"[273, 277): 'FTSE'",ORG,,Fred: Stock market,False,False,False,True
+dev,86,"[306, 309): 'FTO'",ORG,Wrong,,,,Ticker symbol for Notional Guilder Bond Future; futures contracts not considered entities,False,False,True,True
+dev,86,"[923, 926): 'FTO'",ORG,Wrong,,,,Ticker symbol for Notional Guilder Bond Future; futures contracts not considered entities,False,False,False,True
+dev,87,,,Missing,"[181, 191): 'pro-Moscow'",MISC,,,False,True,True,True
+dev,87,,,Missing,"[595, 600): 'Cotti'",PER,,"powers there, "" said Cotti, who",True,True,True,True
+dev,89,,,Missing,"[1042, 1050): 'Armenian'",MISC,,,True,True,True,True
+dev,89,"[336, 347): 'Azerbaijani'",PER,Tag,"[336, 347): 'Azerbaijani'",MISC,17,,False,True,False,False
+dev,90,"[983, 991): 'Onarheim'",LOC,Tag,"[983, 991): 'Onarheim'",PER,17,,True,True,False,False
+dev,91,"[374, 377): 'AXE'",MISC,Tag,"[374, 377): 'AXE'",ORG,14,Fred: AXE is a brand name; see https://en.wikipedia.org/wiki/AXE_telephone_exchange,False,True,False,False
+dev,93,,MISC,Missing,"[1025, 1030): 'Timor'",LOC,,Indonesia's controversial Timor national car,False,True,False,True
+dev,93,"[794, 804): 'Philippine'",LOC,Tag,"[794, 804): 'Philippine'",MISC,16,Philippine government,True,False,False,False
+dev,99,"[1710, 1732): 'Burj al-Laqlaq Society'",LOC,Tag,"[1710, 1732): 'Burj al-Laqlaq Society'",ORG,16,,True,True,False,False
+dev,102,"[172, 178): 'Israel'",LOC,Tag,"[172, 178): 'Israel'",ORG,,Soccer team,False,False,False,True
+dev,102,"[182, 190): 'Bulgaria'",LOC,Tag,"[182, 190): 'Bulgaria'",ORG,7,Soccer team,True,False,False,False
+dev,102,"[19, 25): 'ISRAEL'",LOC,Tag,"[19, 25): 'ISRAEL'",ORG,,Soccer team,False,False,False,True
+dev,102,"[31, 39): 'BULGARIA'",LOC,Tag,"[31, 39): 'BULGARIA'",ORG,,Soccer team,False,False,False,True
+dev,103,"[19, 24): 'IRISH'",MISC,Tag,"[19, 24): 'IRISH'",ORG,13,Soccer team,False,True,False,False
+dev,103,"[214, 220): 'Alpine'",MISC,Tag,"[214, 220): 'Alpine'",ORG,15,ambiguous seems to ref an irish football team,True,False,False,False
+dev,103,"[673, 679): 'Eschen'",LOC,Tag,"[673, 679): 'Eschen'",MISC,10,"Proper noun as adjective: ""Ireland's visit to theÊEschenÊstadium""",True,False,False,False
+dev,104,"[96, 115): 'Republic of Ireland'",LOC,Tag,"[96, 115): 'Republic of Ireland'",ORG,16,Soccer team,False,True,False,False
+dev,106,"[33, 39): 'FAROES'",LOC,Tag,"[33, 39): 'FAROES'",ORG,17,"Could also possibly be MISC, I'm 50/50",True,True,False,False
+dev,108,"[543, 546): 'Aki'",PER,Tag,"[543, 546): 'Aki'",ORG,,,False,False,True,True
+dev,109,"[145, 152): 'England'",LOC,Tag,"[145, 152): 'England'",ORG,,Cricket team,False,False,False,True
+dev,109,"[157, 165): 'Pakistan'",LOC,Tag,"[157, 165): 'Pakistan'",ORG,,Cricket team,False,False,False,True
+dev,109,"[179, 186): 'England'",LOC,Tag,"[179, 186): 'England'",ORG,,Cricket team,False,False,False,True
+dev,109,"[20, 27): 'ENGLAND'",LOC,Tag,"[20, 27): 'ENGLAND'",ORG,,,False,False,False,True
+dev,109,"[30, 38): 'PAKISTAN'",LOC,Tag,"[30, 38): 'PAKISTAN'",ORG,,,False,False,False,True
+dev,109,"[59, 69): 'BIRMINGHAM'",ORG,Tag,"[59, 69): 'BIRMINGHAM'",LOC,17,,True,True,True,False
+dev,109,,,Missing,"[765, 773): 'pakistan'",ORG,,Cricket team,False,True,True,True
+dev,110,"[2192, 2196): 'Jane'",PER,Sentence,"[2192, 2204): 'Jane Quigley'",,17,,False,True,False,False
+dev,110,"[2349, 2361): 'Samokhvalova'",PER,Sentence,"[2340, 2361): ''Svetlana Samokhvalova' ",,17,,False,True,False,False
+dev,110,"[2340, 2348): 'Svetlana'",PER,Sentence,"[2340, 2361): 'Svetlana Samokhvalova'",PER,,Sentence boundary between first and last names,False,True,False,True
+dev,110,"[2349, 2361): 'Samokhvalova'",PER,Sentence,"[2340, 2361): 'Svetlana Samokhvalova'",,,Sentence boundary between first and last name,False,False,True,True
+dev,110,"[2438, 2442): 'Rasa'",PER,Sentence,"[2438, 2452): 'Rasa Mazeikyte'",,17,,False,True,False,False
+dev,112,"[1702, 1710): 'New York'",LOC,Tag,"[1702, 1710): 'New York'",ORG,17,,False,True,False,False
+dev,112,,,Missing,"[2041, 2050): 'Ex-Yankee'",MISC,,,False,True,False,True
+dev,112,"[2973, 2980): 'Chicago'",LOC,Tag,"[2973, 2980): 'Chicago'",ORG,13,Baseball team,False,True,False,False
+dev,112,"[324, 329): 'Texas'",LOC,Tag,"[324, 329): 'Texas'",ORG,17,,False,True,False,False
+dev,112,"[3827, 3838): 'Kansas City'",LOC,Tag,"[3827, 3838): 'Kansas City'",ORG,,Kansas City Royals baseball team,False,False,False,True
+dev,112,"[536, 541): 'Texas'",LOC,Tag,"[536, 541): 'Texas'",ORG,17,,False,True,False,False
+dev,112,"[791, 798): 'Indians'",MISC,Tag,"[791, 798): 'Indians'",ORG,17,,False,True,False,False
+dev,112,"[900, 905): 'Texas'",LOC,Tag,"[900, 905): 'Texas'",ORG,14,Baseball team ,False,True,False,False
+dev,112,"[3804, 3807): 'ERA'",MISC,Wrong,,,17,,False,True,False,False
+dev,112,"[730, 733): 'RBI'",MISC,Wrong,,,,Run batted in,False,False,False,True
+dev,112,"[2962, 2965): 'RBI'",MISC,Wrong,,,,Runs batted in,False,False,False,True
+dev,112,"[2962, 2965): 'RBI'	",MISC,Wrong,,,,"Abbreviation for ""runs batted in"", which isn't a named entity",False,False,False,True
+dev,112,"[3804, 3807): 'ERA'",,Wrong,,,,"Abbreviation for ""earned run average"", which isn't a named entity",False,False,False,True
+dev,115,"[594, 602): 'Stirling'",ORG,Span,"[594, 609): 'Stirling County'",ORG,17,,True,True,False,False
+dev,116,"[19, 24): 'WALES'",LOC,Tag,"[19, 24): 'WALES'",ORG,14,Soccer team,False,True,False,False
+dev,118,"[271, 280): 'Leicester'",LOC,Tag,"[271, 280): 'Leicester'",ORG,,...coachÊBob DwyerÊon his league coaching debut withÊ[Leicester].,False,True,True,True
+dev,118,"[50, 55): 'DWYER'",ORG,Tag,"[50, 55): 'DWYER'",PER,17,,True,True,False,False
+dev,118,"[710, 720): 'Harlequins'",LOC,Tag,"[710, 720): 'Harlequins'",ORG,,Harlequin F.C.,False,True,True,True
+dev,124,"[597, 605): 'Al Unser'",PER,Span,"[597, 608): 'Al Unser Jr'",PER,16,,True,False,False,False
+dev,125,"[188, 197): 'World Cup'",MISC,Span,"[183, 187): '1998 World Cup'",,,,False,True,False,True
+dev,126,"[105, 117): 'South Africa'",LOC,Tag,"[105, 117): 'South Africa'",ORG,,Rugby team,False,False,False,True
+dev,126,"[2795, 2807): 'South Africa'",LOC,Tag,"[2795, 2807): 'South Africa'",ORG,,Rugby team,False,False,False,True
+dev,126,"[3190, 3201): 'New Zealand'",LOC,Tag,"[3190, 3201): 'New Zealand'",ORG,,Rugby team,False,False,False,True
+dev,126,"[350, 361): 'New Zealand'",LOC,Tag,"[350, 361): 'New Zealand'",ORG,,Rugby team,False,False,False,True
+dev,126,"[523, 534): 'New Zealand'",LOC,Tag,"[523, 534): 'New Zealand'",ORG,,Rugby team,False,False,False,True
+dev,127,"[24, 36): 'SOUTH AFRICA'",LOC,Tag,"[24, 36): 'SOUTH AFRICA'",ORG,13,Rugby team,False,True,False,False
+dev,129,"[19, 29): 'MAURITANIA'",LOC,Tag,"[19, 29): 'MAURITANIA'",ORG,14,Soccer team,False,True,False,False
+dev,129,"[40, 45): 'BENIN'",LOC,Tag,"[40, 45): 'BENIN'",ORG,17,Soccer team,False,True,False,False
+dev,130,"[180, 183): 'Rad'",ORG,Span,"[180, 187): 'Rad (B)'",,,,False,False,True,True
+dev,135,"[104, 112): 'Portugal'",LOC,Tag,"[104, 112): 'Portugal'",ORG,,Soccer team,False,False,False,True
+dev,135,"[19, 26): 'ARMENIA'",LOC,Tag,"[19, 26): 'ARMENIA'",ORG,,Soccer team,False,False,True,True
+dev,135,"[31, 39): 'PORTUGAL'",LOC,Tag,"[31, 39): 'PORTUGAL'",ORG,16,Soccer team,False,True,False,False
+dev,135,"[92, 99): 'Armenia'",LOC,Tag,"[92, 99): 'Armenia'",ORG,,Soccer team,False,False,False,True
+dev,136,"[19, 29): 'AZERBAIJAN'",LOC,Tag,"[19, 29): 'AZERBAIJAN'",ORG,13,soccer team,False,True,False,False
+dev,138,"[19, 25): 'SWEDEN'",LOC,Tag,"[19, 25): 'SWEDEN'",ORG,17,Soccer team,False,True,False,False
+dev,138,"[31, 37): 'LATVIA'",LOC,Tag,"[31, 37): 'LATVIA'",ORG,,Soccer team,False,False,False,True
+dev,138,"[86, 92): 'Sweden'",LOC,Tag,"[86, 92): 'Sweden'",ORG,,Soccer team,False,False,False,True
+dev,138,"[98, 104): 'Latvia'",LOC,Tag,"[98, 104): 'Latvia'",ORG,,Soccer team,False,False,False,True
+dev,139,"[19, 26): 'BELARUS'",LOC,Tag,"[19, 26): 'BELARUS'",ORG,16,National soccer team,False,True,False,False
+dev,140,"[128, 136): 'European'",MISC,Span,"[128, 145): 'European Under-21'",,,https://en.wikipedia.org/wiki/UEFA_European_Under-21_Championship,False,False,True,True
+dev,141,,,Missing,"[1279, 1286): 'Jansher'",PER,,,True,True,True,True
+dev,144,"[19, 24): 'SPAIN'",LOC,Tag,"[19, 24): 'SPAIN'",ORG,17,Slightly ambiguous,False,True,False,False
+dev,146,"[229, 242): 'United States'",LOC,Tag,"[229, 242): 'United States'",ORG,,Tennis team,False,False,False,True
+dev,146,"[246, 257): 'Netherlands'",LOC,Tag,"[246, 257): 'Netherlands'",ORG,,Tennis team,False,False,True,True
+dev,146,"[258, 272): 'Czech Republic'",LOC,Tag,"[258, 272): 'Czech Republic'",ORG,,Tennis team,False,False,False,True
+dev,146,"[276, 283): 'Germany'",LOC,Tag,"[276, 283): 'Germany'",ORG,,Tennis team,False,False,False,True
+dev,146,"[284, 290): 'France'",LOC,Tag,"[284, 290): 'France'",ORG,,Tennis team,False,False,False,True
+dev,146,"[294, 299): 'Japan'",LOC,Tag,"[294, 299): 'Japan'",ORG,,Tennis team,False,False,False,True
+dev,146,"[300, 305): 'Spain'",LOC,Tag,"[300, 305): 'Spain'",ORG,,Tennis team,False,False,False,True
+dev,146,"[309, 316): 'Belgium'",LOC,Tag,"[309, 316): 'Belgium'",ORG,,Tennis team,False,False,False,True
+dev,146,"[409, 416): 'Austria'",LOC,Tag,"[409, 416): 'Austria'",ORG,,Tennis team,False,False,False,True
+dev,146,"[420, 427): 'Croatia'",LOC,Tag,"[420, 427): 'Croatia'",ORG,,Tennis team,False,False,True,True
+dev,146,"[428, 439): 'Switzerland'",LOC,Tag,"[428, 439): 'Switzerland'",ORG,,Tennis team,False,False,True,True
+dev,146,"[443, 458): 'Slovak Republic'",LOC,Tag,"[443, 458): 'Slovak Republic'",ORG,,Tennis team,False,False,False,True
+dev,146,"[459, 468): 'Argentina'",LOC,Tag,"[459, 468): 'Argentina'",ORG,,Tennis team,False,False,False,True
+dev,146,"[472, 483): 'South Korea'",LOC,Tag,"[472, 483): 'South Korea'",ORG,,Tennis team,False,False,True,True
+dev,146,"[484, 493): 'Australia'",LOC,Tag,"[484, 493): 'Australia'",ORG,,Tennis team,False,False,True,True
+dev,146,"[497, 509): 'South Africa'",LOC,Tag,"[497, 509): 'South Africa'",ORG,,Tennis team,False,False,False,True
+dev,147,"[179, 183): 'U.S.'",LOC,Tag,"[179, 183): 'U.S.'",ORG,,U.S. soccer team,False,False,False,True
+dev,147,"[255, 266): 'El Salvador'",LOC,Tag,"[255, 266): 'El Salvador'",ORG,,El Salvadorean soccer team,False,False,False,True
+dev,147,"[29, 40): 'EL SALVADOR'",LOC,Tag,"[29, 40): 'EL SALVADOR'",ORG,9,U.S. BEAT EL SALVADOR 3-1.,True,False,False,False
+dev,147,"[73, 86): 'United States'",LOC,Tag,"[73, 86): 'United States'",ORG,,TheÊUnited StatesÊbeatÊEl SalvadorÊ3-1,False,False,False,True
+dev,147,"[92, 103): 'El Salvador'",LOC,Tag,"[92, 103): 'El Salvador'",ORG,,TheÊUnited StatesÊbeatÊEl SalvadorÊ3-1,False,False,False,True
+dev,148,"[1266, 1273): 'CHICAGO'",LOC,Tag,"[1266, 1273): 'CHICAGO'",ORG,,Baseball team,False,False,False,True
+dev,148,"[1285, 1295): 'PITTSBURGH'",LOC,Tag,"[1285, 1295): 'PITTSBURGH'",ORG,,Baseball team,False,False,False,True
+dev,148,"[1313, 1321): 'NEW YORK'",LOC,Tag,"[1313, 1321): 'NEW YORK'",ORG,,Baseball team,False,False,False,True
+dev,148,"[1333, 1343): 'CINCINNATI'",LOC,Tag,"[1333, 1343): 'CINCINNATI'",ORG,17,,False,True,False,False
+dev,148,"[1359, 1371): 'PHILADELPHIA'",LOC,Tag,"[1359, 1371): 'PHILADELPHIA'",ORG,16,,False,True,False,False
+dev,148,"[1385, 1393): 'MONTREAL'",LOC,Tag,"[1385, 1393): 'MONTREAL'",ORG,,Baseball team,False,False,False,True
+dev,148,"[1406, 1414): 'ST LOUIS'",LOC,Tag,"[1406, 1414): 'ST LOUIS'",ORG,,Baseball team,False,False,False,True
+dev,148,"[669, 676): 'DETROIT'",LOC,Tag,"[669, 676): 'DETROIT'",ORG,,Baseball team,False,False,False,True
+dev,148,"[690, 697): 'SEATTLE'",LOC,Tag,"[690, 697): 'SEATTLE'",ORG,14,team,False,True,False,False
+dev,148,"[709, 716): 'TORONTO'",LOC,Tag,"[709, 716): 'TORONTO'",ORG,13,team,False,True,False,False
+dev,148,"[730, 739): 'MILWAUKEE'",LOC,Tag,"[730, 739): 'MILWAUKEE'",ORG,,Baseball team,False,False,False,True
+dev,148,"[753, 758): 'TEXAS'",LOC,Tag,"[753, 758): 'TEXAS'",ORG,,Baseball team,False,False,False,True
+dev,148,"[769, 776): 'OAKLAND'",LOC,Tag,"[769, 776): 'OAKLAND'",ORG,,Baseball team,False,False,False,True
+dev,148,"[789, 799): 'CALIFORNIA'",LOC,Tag,"[789, 799): 'CALIFORNIA'",ORG,14,,False,True,False,False
+dev,148,"[975, 991): 'CENTRAL DIVISION'",MISC,Wrong,,,16,Divisions donÕt count ,False,True,False,False
+dev,148,"[228, 244): 'EASTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+dev,148,"[376, 392): 'CENTRAL DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+dev,148,"[514, 530): 'WESTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+dev,148,"[816, 832): 'EASTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+dev,148,"[1112, 1128): 'WESTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+dev,149,"[81, 93): 'Major League'",MISC,Sentence,"[81, 102): 'Major League Baseball'",,,"Sentence boundary between ""League"" and ""Baseball""",False,False,True,True
+dev,150,"[2463, 2470): 'Chicago'",LOC,Tag,"[2463, 2470): 'Chicago'",ORG,,,False,False,True,True
+dev,150,"[2533, 2540): 'Atlanta'",LOC,Tag,"[2533, 2540): 'Atlanta'",ORG,,Atlanta Braves,False,False,False,True
+dev,150,"[3115, 3123): 'Montreal'",LOC,Tag,"[3115, 3123): 'Montreal'",ORG,17,,False,True,False,False
+dev,150,"[3142, 3150): 'Montreal'",LOC,Tag,"[3142, 3150): 'Montreal'",ORG,17,,False,True,False,False
+dev,150,"[101, 104): 'ERA'",MISC,Wrong,,,17,,False,True,False,False
+dev,150,"[40, 43): 'ERA'",MISC,Wrong,,,15,,False,True,False,False
+dev,150,"[164, 167): 'RBI'",MISC,Wrong,,,,Runs batted in,False,False,False,True
+dev,150,"[3709, 3712): 'RBI'",MISC,Wrong,,,,Runs batted in,False,False,False,True
+dev,150,"[3953, 3956): 'RBI'",MISC,Wrong,,,,Runs batted in,False,False,False,True
+dev,150,"[4459, 4462): 'RBI'",MISC,Wrong,,,,Runs batted in,False,False,False,True
+dev,150,"[4617, 4620): 'RBI'",MISC,Wrong,,,,Runs batted in,False,False,False,True
+dev,152,,,Missing,"[41, 44): 'WBO'",ORG,,,False,False,False,True
+dev,153,"[100, 107): 'Austria'",LOC,Tag,"[100, 107): 'Austria'",ORG,,Soccer team,False,False,False,True
+dev,153,,,Missing,"[1465, 1470): 'Scots'",MISC,,,False,True,True,True
+dev,153,"[163, 171): 'Scotland'",LOC,Tag,"[163, 171): 'Scotland'",ORG,,Soccer team,False,False,False,True
+dev,153,"[1651, 1658): 'Austria'",LOC,Tag,"[1651, 1658): 'Austria'",ORG,,Soccer team,False,False,False,True
+dev,153,"[1890, 1898): 'Scotland'",LOC,Tag,"[1890, 1898): 'Scotland'",ORG,,Soccer team,False,False,False,True
+dev,153,"[19, 26): 'AUSTRIA'",LOC,Tag,"[19, 26): 'AUSTRIA'",ORG,,Soccer team,False,False,False,True
+dev,153,"[307, 315): 'Scotland'",LOC,Tag,"[307, 315): 'Scotland'",ORG,,Soccer team,False,False,False,True
+dev,153,"[330, 337): 'Belarus'",LOC,Tag,"[330, 337): 'Belarus'",ORG,,Soccer team,False,False,False,True
+dev,153,"[36, 44): 'SCOTLAND'",LOC,Tag,"[36, 44): 'SCOTLAND'",ORG,17,Soccer team,False,True,True,False
+dev,153,"[418, 425): 'Austria'",LOC,Tag,"[418, 425): 'Austria'",ORG,,Soccer team,False,False,False,True
+dev,153,"[786, 794): 'Scotland'",LOC,Tag,"[786, 794): 'Scotland'",ORG,,Soccer team,False,False,False,True
+dev,153,"[886, 894): 'Scotland'",LOC,Tag,"[886, 894): 'Scotland'",ORG,,Soccer team,False,False,False,True
+dev,155,"[19, 25): 'FRANCE'",LOC,Tag,"[19, 25): 'FRANCE'",ORG,13,,False,True,False,False
+dev,156,"[19, 25): 'FRANCE'",LOC,Tag,"[19, 25): 'FRANCE'",ORG,17,,False,True,False,False
+dev,157,"[39, 45): 'TURKEY'",LOC,Tag,"[39, 45): 'TURKEY'",ORG,17,,False,True,False,False
+dev,158,,,Missing,"[42, 56): 'FIRST DIVISION'",MISC,,,False,False,False,True
+dev,158,"[120, 128): 'division'",MISC,Wrong,,,16, divisions of leagues not entities,True,False,False,False
+dev,159,,,Missing,"[37, 51): 'FIRST DIVISION'",MISC,,,False,False,False,True
+dev,159,"[114, 122): 'division'",MISC,Wrong,,,16, divisions of leagues not entities,True,False,False,False
+dev,160,"[32, 38): 'TURKEY'",LOC,Tag,"[32, 38): 'TURKEY'",ORG,16,Zach: Soccer nat team,False,True,False,False
+dev,161,"[104, 112): 'Scotland'",LOC,Tag,"[104, 112): 'Scotland'",ORG,,Soccer team,False,False,False,True
+dev,161,"[19, 26): 'AUSTRIA'",LOC,Tag,"[19, 26): 'AUSTRIA'",ORG,,Soccer team,False,False,False,True
+dev,161,"[41, 49): 'SCOTLAND'",LOC,Tag,"[41, 49): 'SCOTLAND'",ORG,,Soccer team,False,False,False,True
+dev,161,"[92, 99): 'Austria'",LOC,Tag,"[92, 99): 'Austria'",ORG,,Soccer team,False,False,False,True
+dev,163,"[124, 130): 'Brazil'",LOC,Tag,"[124, 130): 'Brazil'",ORG,,Fred: National soccer team,False,False,False,True
+dev,163,"[190, 201): 'Netherlands'",LOC,Tag,"[190, 201): 'Netherlands'",ORG,,Fred: National soccer team,False,False,False,True
+dev,163,"[256, 262): 'Brazil'",LOC,Tag,"[256, 262): 'Brazil'",ORG,,Fred: National soccer team,False,False,False,True
+dev,163,"[94, 109): 'The Netherlands'",LOC,Tag,"[94, 109): 'The Netherlands'",ORG,16,Zach: Nat soccer team,False,True,False,False
+dev,165,"[25, 45): 'TATTERSALLS BREEDERS'",MISC,Span,"[25, 52): 'TATTERSALLS BREEDERS STAKES'",MISC,17,,True,True,True,False
+dev,165,"[25, 45): 'TATTERSALLS BREEDERS'	",MISC,Span,"[25, 52): 'TATTERSALLS BREEDERS STAKES'	",,,,False,False,False,True
+dev,165,"[114, 120): 'Stakes'",MISC,Sentence,"[93, 120): 'Tattersalls Breeders Stakes'",,17,,False,True,False,False
+dev,165,"[114, 120): 'Stakes'",,Wrong,,,,See previous row,False,False,False,True
+dev,166,"[163, 172): 'World Cup'",MISC,Span,"[158, 172): '1998 World Cup'",MISC,,,False,True,True,True
+dev,170,"[1363, 1373): 'Red Shirts'",MISC,Tag,"[1363, 1373): 'Red Shirts'",ORG,13,"""1860- Giuseppe Garibaldi leading his "" Red Shirts "" seized Naples in the Italian war of liberation against the Austrians""",False,True,False,False
+dev,170,"[488, 494): 'Eugene'",ORG,Tag,"[488, 494): 'Eugene'",PER,16,,True,True,True,False
+dev,172,,,Missing,"[969, 982): 'Conservatives'",MISC,,Members of the Conservative party,False,True,True,True
+dev,175,"[252, 264): 'London-based'",MISC,Token,"[252, 258): 'London'",LOC,15,,False,True,False,False
+dev,178,,,Missing,"[105, 115): 'Afrikaners'",MISC,7,,True,False,False,False
+dev,178,"[105, 115): 'Afrikaners'",,Missing,,MISC,,,False,False,False,True
+dev,180,"[687, 699): 'Bosnian Serb'",MISC,Both,"[687, 708): 'Bosnian Serb republic'",LOC,15,Fred: Appears to be a reference to https://en.wikipedia.org/wiki/Republika_Srpska,False,True,False,False
+dev,181,"[1761, 1774): 'Moscow-backed'",MISC,Token,"[1761, 1767): 'Moscow'",LOC,15,I think this needs to be seperated,False,True,False,False
+dev,182,"[662, 670): 'division'",MISC,Wrong,,,17,,True,True,False,False
+dev,185,"[54, 62): 'SANTIAGO'",PER,Tag,"[54, 62): 'SANTIAGO'",LOC,17,,True,True,True,False
+dev,191,"[1031, 1037): 'Korean'",MISC,Span,"[1031, 1041): 'Korean War'",,,,False,True,True,True
+dev,191,"[1031, 1037): 'Korean'",,Span,"[1031, 1041): 'Korean War'",MISC,13,,True,False,False,False
+dev,191,"[660, 666): 'Korean'",MISC,Span,"[660, 670): 'Korean War'",MISC,16,,False,True,False,False
+dev,194,"[537, 544): 'Chinese'",MISC,Both,"[537, 556): 'Chinese Nationalist'",ORG,16,,False,True,False,False
+dev,194,"[537, 544): 'Chinese'",MISC,Span,"[537, 556): 'Chinese Nationalist'",,,Kuomintang party,False,True,True,True
+dev,194,"[537, 544): 'Chinese'",,Span,"[537, 556): 'Chinese Nationalist'",MISC,9,Reference to Kuomintang Party as an adjective,True,False,False,False
+dev,198,"[39, 47): 'aid-U.N.'",MISC,Token,"[43, 47): 'U.N.'",ORG,17,,False,True,True,False
+dev,199,,,Missing,"[106, 122): 'Turkish-operated'",MISC,,,True,True,True,True
+dev,199,"[139, 147): 'Bahraini'",LOC,Tag,"[139, 147): 'Bahraini'",MISC,,,False,True,True,True
+dev,199,"[39, 47): 'Bahraini'",LOC,Tag,"[39, 47): 'Bahraini'",MISC,,,False,True,True,True
+dev,200,,,Missing,"[1241, 1255): 'KDP-controlled'",MISC,,,True,True,True,True
+dev,204,"[160, 171): 'Lilac Falls'",LOC,Span,"[160, 177): 'Lilac Falls Motel'",LOC,15,Motel is capitolized,True,False,False,False
+dev,206,"[2266, 2273): 'Marines'",MISC,Tag,"[2266, 2273): 'Marines'",ORG,17,branch of millitary,False,True,False,False
+dev,206,"[458, 471): 'Mediterranean'",MISC,Tag,"[458, 471): 'Mediterranean'",LOC,,"""Enterprise was in the eastern Mediterranean""",False,True,False,True
+dev,211,,,Missing,"[11, 15): 'Nato'",ORG,,,True,True,False,True
+dev,214,"[1643, 1648): 'Oscar'",PER,Tag,"[1643, 1648): 'Oscar'",MISC,16,,False,True,False,False
+dev,214,,,Missing,"[75, 81): 'VENICE'",LOC,13,,True,False,False,False
+test,0,"[19, 24): 'JAPAN'",LOC,Tag,"[19, 24): 'JAPAN'",ORG,14,Soccer team,False,True,False,False
+test,0,"[40, 45): 'CHINA'",PER,Tag,"[40, 45): 'CHINA'",LOC,16,,True,False,False,False
+test,1,"[42, 47): 'ITALY'",LOC,Tag,"[42, 47): 'ITALY'",ORG,17,Soccer team,False,True,False,False
+test,2,"[35, 40): 'JAPAN'",LOC,Tag,"[35, 40): 'JAPAN'",ORG,17,Soccer team ,False,True,False,False
+test,3,"[21, 37): 'SKIING-WORLD CUP'",MISC,Token,"[28, 37): 'WORLD CUP'",MISC,,,False,False,False,True
+test,3,"[21, 37): 'SKIING-WORLD CUP'",MISC,Token,"[28,37)'WORLD CUP'",,17,CHECK span later,False,True,False,False
+test,4,"[141, 146): 'Japan'",LOC,Tag,"[141, 146): 'Japan'",ORG,7,,True,False,False,False
+test,4,"[149, 154): 'Syria'",LOC,Tag,"[149, 154): 'Syria'",ORG,7,,True,False,False,False
+test,4,"[181, 186): 'Japan'",LOC,Tag,"[181, 186): 'Japan'",ORG,,Soccer team,False,False,False,True
+test,4,"[232, 237): 'Syria'",LOC,Tag,"[232, 237): 'Syria'",ORG,,Soccer team,False,False,False,True
+test,4,"[276, 281): 'China'",LOC,Tag,"[276, 281): 'China'",ORG,,Soccer team,False,False,False,True
+test,4,"[284, 294): 'Uzbekistan'",,Tag,"[284, 294): 'Uzbekistan'",ORG,12,Soccer team,True,False,False,False
+test,4,"[462, 472): 'Uzbekistan'",LOC,Tag,"[462, 472): 'Uzbekistan'",ORG,,Soccer team,False,False,False,True
+test,4,"[487, 492): 'Japan'",LOC,Tag,"[487, 492): 'Japan'",ORG,,,False,False,False,True
+test,4,"[507, 512): 'Syria'",LOC,Tag,"[507, 512): 'Syria'",ORG,,,False,False,False,True
+test,4,"[507, 512): 'Syria'	",LOC,Tag,"[507, 512): 'Syria'	",ORG,,Soccer team,False,False,False,True
+test,4,"[527, 532): 'China'",LOC,Tag,"[527, 532): 'China'",ORG,8,Soccer team,True,False,False,False
+test,5,"[213, 221): 'Pakistan'",LOC,Tag,"[213, 221): 'Pakistan'",ORG,13,team,False,True,False,False
+test,5,"[31, 42): 'NEW ZEALAND'",LOC,Tag,"[31, 42): 'NEW ZEALAND'",ORG,15,cricket team,False,True,False,False
+test,6,"[88, 110): 'English F.A. Challenge'",MISC,Sentence,"[88, 114): 'English F.A. Challenge Cup'",,17,,False,True,False,False
+test,11,"[495, 503): 'Desvonde'",PER,Sentence,"[495, 509): 'Desvonde Botes'",,17,,False,True,False,False
+test,11,"[504, 509): 'Botes'",PER,Sentence,"[495, 509): 'Desvonde Botes'",PER,,Sentence boundary between first and last name,False,False,True,True
+test,15,"[1241, 1250): 'Australia'",LOC,Tag,"[1241, 1250): 'Australia'",ORG,,"Australian cricket team: ""Australia won by five wickets.""",False,False,False,True
+test,15,"[32, 43): 'WEST INDIES'",LOC,Tag,"[32, 43): 'WEST INDIES'",ORG,17,Cricket team,False,True,False,False
+test,16,"[100, 111): 'West Indies'",LOC,Tag,"[100, 111): 'West Indies'",ORG,,Cricket team,False,False,False,True
+test,16,"[20, 29): 'AUSTRALIA'",LOC,Tag,"[20, 29): 'AUSTRALIA'",ORG,,Cricket team,False,False,False,True
+test,16,"[217, 228): 'West Indies'",LOC,Tag,"[217, 228): 'West Indies'",ORG,,Cricket team,False,False,False,True
+test,16,"[284, 293): 'Australia'",LOC,Tag,"[284, 293): 'Australia'",ORG,,Cricket team,False,False,False,True
+test,16,"[35, 46): 'WEST INDIES'",LOC,Tag,"[35, 46): 'WEST INDIES'",ORG,17,Cricket team,False,True,False,False
+test,16,"[85, 94): 'Australia'",LOC,Tag,"[85, 94): 'Australia'",ORG,,Cricket team,False,False,False,True
+test,17,"[188, 197): 'Australia'",LOC,Tag,"[188, 197): 'Australia'",ORG,,Cricket team,False,False,False,True
+test,17,"[20, 31): 'WEST INDIES'",LOC,Tag,"[20, 31): 'WEST INDIES'",ORG,17,Cricket team,False,True,False,False
+test,17,"[60, 69): 'AUSTRALIA'",LOC,Tag,"[60, 69): 'AUSTRALIA'",ORG,,Cricket team,False,False,False,True
+test,17,"[92, 103): 'West Indies'",LOC,Tag,"[92, 103): 'West Indies'",ORG,,Cricket team,False,False,False,True
+test,18,"[143, 151): 'Tasmania'",LOC,Tag,"[143, 151): 'Tasmania'",ORG,,Cricket team,False,False,False,True
+test,18,"[156, 164): 'Victoria'",LOC,Tag,"[156, 164): 'Victoria'",ORG,,Cricket team,False,False,False,True
+test,18,"[194, 202): 'Tasmania'",LOC,Tag,"[194, 202): 'Tasmania'",ORG,17,Cricket team,False,True,False,False
+test,18,"[20, 36): 'SHEFFIELD SHIELD'",MISC,Tag,"[20, 36): 'SHEFFIELD SHIELD'",ORG,17,Cricket team,False,True,False,False
+test,20,"[20, 31): 'WEST INDIES'",LOC,Tag,"[20, 31): 'WEST INDIES'",ORG,17,Cricket team,False,True,False,False
+test,20,"[230, 239): 'Australia'",LOC,Tag,"[230, 239): 'Australia'",ORG,,Cricket team,False,False,False,True
+test,20,"[247, 256): 'Melbourne'",LOC,Span,"[247, 271): 'Melbourne Cricket Ground'",,,,False,False,True,True
+test,20,"[290, 299): 'Australia'",LOC,Tag,"[290, 299): 'Australia'",ORG,,Cricket team,False,False,False,True
+test,20,"[482, 493): 'West Indies'",LOC,Tag,"[482, 493): 'West Indies'",ORG,,Cricket team,False,False,False,True
+test,21,"[713, 718): 'Indra'",PER,Sentence,"[713, 725): 'Indra Wijaya'",,17,,False,True,False,False
+test,22,"[19, 23): 'ARAB'",MISC,Both,"[19, 35): 'ARAB CONTRACTORS'",ORG,17,,False,True,False,False
+test,22,,,Missing,"[299, 310): 'Contractors'",ORG,,,False,True,True,True
+test,22,"[299, 310): 'Contractors'",,Missing,,ORG,,"short for ""Arab Contractors""",False,False,False,True
+test,23,"[1098, 1105): 'BUFFALO'",LOC,Tag,"[1098, 1105): 'BUFFALO'",ORG,15,,False,True,False,False
+test,23,"[1142, 1152): 'WASHINGTON'",LOC,Tag,"[1142, 1152): 'WASHINGTON'",ORG,,Hockey team,True,True,True,True
+test,23,"[1153, 1161): 'MONTREAL'",ORG,Tag,"[1153, 1161): 'MONTREAL'",ORG,14,,False,True,False,False
+test,23,"[1165, 1172): 'CHICAGO'",LOC,Tag,"[1165, 1172): 'CHICAGO'",ORG,,Hockey team,False,False,False,True
+test,23,"[1189, 1195): 'DALLAS'",LOC,Tag,"[1189, 1195): 'DALLAS'",ORG,,Hockey team,False,False,False,True
+test,23,"[1208, 1216): 'COLORADO'",LOC,Tag,"[1208, 1216): 'COLORADO'",ORG,,Hockey team,False,False,False,True
+test,23,"[1227, 1235): 'EDMONTON'",LOC,Tag,"[1227, 1235): 'EDMONTON'",ORG,,Hockey team,False,False,False,True
+test,23,"[628, 637): 'TAMPA BAY'",ORG,Tag,"[628, 637): 'TAMPA BAY'",ORG,14,,False,True,False,False
+test,23,"[94, 109): 'National Hockey'",ORG,Sentence,"[94, 116): 'National Hockey League'",,17,,True,True,True,False
+test,23,"[673, 689): 'CENTRAL DIVISION'",MISC,Wrong,,,17,,False,True,False,False
+test,24,"[227, 233): 'League'",ORG,Sentence,"[211, 233): 'National Hockey League'",,17,,False,True,True,False
+test,24,"[227, 233): 'League'",ORG,Wrong,"[211, 233): 'National Hockey League'",,15,,True,False,False,False
+test,24,"[211, 226): 'National Hockey'",ORG,Sentence,,,,,False,False,False,True
+test,25,"[1748, 1760): 'Philadelphia'",LOC,Tag,"[1748, 1760): 'Philadelphia'",ORG,,Philadelphia Eagles,True,False,True,True
+test,25,"[823, 835): 'Philadelphia'",LOC,Tag,"[823, 835): 'Philadelphia'",ORG,,Philadelphia Eagles,True,True,True,True
+test,26,"[1042, 1048): 'BOSTON'",LOC,Tag,"[1042, 1048): 'BOSTON'",ORG,,Boston basketball team,False,False,False,True
+test,26,"[1062, 1069): 'DETROIT'",LOC,Tag,"[1062, 1069): 'DETROIT'",ORG,17,basketball team,False,True,False,False
+test,26,"[1082, 1087): 'MIAMI'",LOC,Tag,"[1082, 1087): 'MIAMI'",ORG,17,bball team,False,True,False,False
+test,26,"[1099, 1109): 'SACRAMENTO'",LOC,Tag,"[1099, 1109): 'SACRAMENTO'",ORG,17,baskeball team,False,True,False,False
+test,26,"[1123, 1134): 'SAN ANTONIO'",LOC,Tag,"[1123, 1134): 'SAN ANTONIO'",ORG,,Basketball Team,False,False,False,True
+test,26,"[1148, 1152): 'UTAH'",LOC,Tag,"[1148, 1152): 'UTAH'",ORG,17,basketball team,False,True,False,False
+test,26,"[1166, 1174): 'PORTLAND'",LOC,Tag,"[1166, 1174): 'PORTLAND'",ORG,17,basketball team,False,True,False,False
+test,26,"[1186, 1198): 'GOLDEN STATE'",LOC,Tag,"[1186, 1198): 'GOLDEN STATE'",ORG,16,,False,True,False,False
+test,26,"[1210, 1219): 'LA LAKERS'",LOC,Tag,"[1210, 1219): 'LA LAKERS'",ORG,,Basketball Team,False,False,False,True
+test,26,"[94, 102): 'National'",ORG,Sentence,"[94, 125): 'National Basketball Association'",,17,,False,True,False,False
+test,26,"[236, 244): 'ATLANTIC'",LOC,Wrong,,,,Conferences/divisions of leagues not considered entities,False,False,False,True
+test,26,"[822, 829): 'PACIFIC'",LOC,Wrong,,MISC,,Conferences/divisions of leagues not considered entities,False,False,False,True
+test,26,"[94, 102): 'National'",,Wrong,,,,See next line,False,False,False,True
+test,27,"[1250, 1257): 'CHICAGO'",LOC,Tag,"[1250, 1257): 'CHICAGO'",ORG,,Football team,False,False,False,True
+test,27,"[1271, 1281): 'CINCINNATI'",LOC,Tag,"[1271, 1281): 'CINCINNATI'",ORG,,Football team,False,False,False,True
+test,27,"[1292, 1301): 'GREEN BAY'",LOC,Tag,"[1292, 1301): 'GREEN BAY'",ORG,,Football team,False,False,False,True
+test,27,"[1318, 1325): 'HOUSTON'",LOC,Tag,"[1318, 1325): 'HOUSTON'",ORG,17,football team,False,True,False,False
+test,27,"[1339, 1344): 'MIAMI'",LOC,Tag,"[1339, 1344): 'MIAMI'",ORG,17,football team,False,True,False,False
+test,27,"[1356, 1367): 'NEW ORLEANS'",LOC,Tag,"[1356, 1367): 'NEW ORLEANS'",ORG,,Football team,False,False,False,True
+test,27,"[1381, 1391): 'PITTSBURGH'",LOC,Tag,"[1381, 1391): 'PITTSBURGH'",ORG,,Football team,False,False,False,True
+test,27,"[1406, 1415): 'TAMPA BAY'",LOC,Tag,"[1406, 1415): 'TAMPA BAY'",ORG,16,,False,True,False,False
+test,27,"[1426, 1433): 'ARIZONA'",LOC,Tag,"[1426, 1433): 'ARIZONA'",ORG,17,football team,False,True,False,False
+test,27,"[1445, 1456): 'NEW ENGLAND'",LOC,Tag,"[1445, 1456): 'NEW ENGLAND'",ORG,,Football team,False,False,False,True
+test,27,"[1468, 1475): 'SEATTLE'",LOC,Tag,"[1468, 1475): 'SEATTLE'",ORG,17,football team,False,True,False,False
+test,27,"[1488, 1501): 'SAN FRANCISCO'",LOC,Tag,"[1488, 1501): 'SAN FRANCISCO'",ORG,,Football team,False,False,False,True
+test,27,"[1515, 1522): 'DETROIT'",LOC,Tag,"[1515, 1522): 'DETROIT'",ORG,,Football team,False,False,False,True
+test,27,"[1557, 1564): 'OAKLAND'",LOC,Tag,"[1557, 1564): 'OAKLAND'",ORG,,Football team,False,False,False,True
+test,27,"[208, 216): 'AMERICAN'",MISC,Both,"[208, 236): 'AMERICAN FOOTBALL CONFERENCE'",ORG,13,CHECK: I think this is a league and not a division ,False,True,False,False
+test,27,"[565, 573): 'X-DENVER'",MISC,Token,"[567, 573): 'DENVER'",ORG,16,"split on '-', X"" is an annotation""",True,True,False,False
+test,27,,,Token,"[567, 573): 'DENVER'",,10,"""X-"" prefix is a footnote, meaning ""CLINCHED DIVISION TITLE""",True,False,False,False
+test,27,"[889, 900): 'Y-GREEN BAY'",MISC,Token,"[891, 900): 'GREEN BAY'",ORG,16,"split on '-', Y"" is an annotation""",True,True,False,False
+test,27,"[410, 412): 'PA'",ORG,Wrong,,,14,Points Allowed,True,True,False,False
+test,28,"[82, 90): 'National'",ORG,Sentence,"[82, 106): 'National Football League'",,16,Also sentence boundary after National,True,False,False,False
+test,28,"[91, 99): 'Football'",LOC,Sentence,"[82, 106): 'National Football League'",ORG,16,,True,False,False,False
+test,28,"[91, 99): 'Football'",LOC,Sentence,"[82,106): 'National Football League'",ORG,17,,False,True,False,False
+test,28,"[82, 90): 'National'",ORG,Sentence,"[82,106): 'National Football League'",,17,,False,True,False,False
+test,28,"[91, 99): 'Football'",LOC,Wrong,,,,"""National Football League"" with sentence boundary and tag issues",False,False,False,True
+test,28,"[100, 106): 'League'",LOC,Wrong,,,,"""National Football League"" with sentence boundary and tag issues",False,False,False,True
+test,28,"[82, 90): 'National'",,Wrong,,,,See two lines down,False,False,False,True
+test,28,"[91, 99): 'Football'",,Wrong,,,,See next line,False,False,False,True
+test,29,"[220, 231): 'Rotary Club'",ORG,Span,"[220, 242): 'Rotary Club of Houston'",,,,False,True,False,True
+test,29,"[25, 44): 'FOOTBALL-OHIO STATE'",MISC,Token,"[34, 44): 'OHIO STATE'",ORG,16,"Need to split on '-' ""FOOTBALL-OHIO""",True,False,False,False
+test,29,"[25, 44): 'FOOTBALL-OHIO STATE'",MISC,Token,"[34,44): 'OHIO STATE'",ORG,17,,False,True,False,False
+test,29,"[235, 242): 'Houston'",LOC,Wrong,,,,,False,True,False,True
+test,31,"[561, 571): 'Schalke 04'",ORG,Span,"[561, 568): 'Schalke'",ORG,17,,False,True,False,False
+test,32,"[170, 177): 'Jocelyn'",PER,Sentence,"[170, 188): 'Jocelyn Gourvennec'",,17,,False,True,False,False
+test,33,,,Missing,"[151, 159): 'Starbuck'",PER,13,,True,True,False,False
+test,36,"[349, 358): 'Karlsruhe'",LOC,Tag,"[349, 358): 'Karlsruhe'",ORG,17,Soccer team,True,True,True,False
+test,36,"[385, 391): 'Dundee'",ORG,Tag,"[385, 391): 'Dundee'",PER,16,,True,True,True,False
+test,36,"[398, 406): 'Freiburg'",LOC,Tag,"[398, 406): 'Freiburg'",ORG,17,Soccer team,True,True,True,False
+test,38,"[43, 51): 'PORTUGAL'",LOC,Tag,"[43, 51): 'PORTUGAL'",ORG,17,Soccer team,False,True,False,False
+test,38,"[99, 104): 'Porto'",ORG,Tag,"[99, 104): 'Porto'",ORG,17,Soccer team,False,True,False,False
+test,39,"[1002, 1010): 'Gheorghe'",PER,Sentence,"[1002, 1018): 'Gheorghe Popescu'",,,Sentence boundary between first and last name,True,True,False,True
+test,39,"[1011, 1018): 'Popescu'",PER,Sentence,"[1002, 1018): 'Gheorghe Popescu'",PER,,Sentence boundary between first and last name,False,False,True,True
+test,39,"[1002, 1010): 'Gheorghe'",PER,Sentence,"[1002, 1018): 'Gheorghe popescu'",,17,,False,True,False,False
+test,39,"[1093, 1099): 'laPena'",PER,Sentence,"[1085, 1099): 'Ivan de la Pena'",,16,also token error on 'laPena' → 'la Pena',True,False,False,False
+test,39,"[1085, 1092): 'Ivan de'",PER,Sentence,"[1085, 1099): 'Ivan de laPena'",,17,,False,True,False,False
+test,39,"[1093, 1099): 'laPena'",PER,Sentence,"[1085, 1099): 'Ivan de laPena'",PER,,Sentence boundary between first and last name,False,False,True,True
+test,39,"[1121, 1125): 'Luis'",PER,Sentence,"[1121, 1133): 'Luis Enrique'",,17,,True,True,False,False
+test,39,"[1126, 1133): 'Enrique'",PER,Sentence,"[1121, 1133): 'Luis Enrique'",PER,,Sentence boundary between first and last name,False,False,True,True
+test,39,"[1158, 1175): 'AbelardoFernandez'",PER,Token,"[1158, 1175): 'Abelardo Fernandez'",PER,,"Missing space between ""Abelardo"" and ""Fernandez"".",False,False,False,True
+test,39,"[1243, 1249): 'Albert'",PER,Sentence,"[1243, 1256): 'Albert Ferrer'",,17,,True,True,False,False
+test,39,"[1250, 1256): 'Ferrer'",PER,Sentence,"[1243, 1256): 'Albert Ferrer'",PER,,Sentence boundary between first and last name,False,False,True,True
+test,39,"[925, 934): 'Guillermo'",PER,Sentence,"[925, 939): 'Guillermo Amor'",,17,,True,True,False,False
+test,39,"[935, 939): 'Amor'",PER,Sentence,"[925, 939): 'Guillermo Amor'",PER,,Sentence boundary between first and last name,False,False,True,True
+test,41,"[674, 682): 'Sporting'",ORG,Span,"[674, 688): 'Sporting Gijon'",ORG,17,,True,True,False,False
+test,42,"[19, 24): 'SPAIN'",LOC,Tag,"[19, 24): 'SPAIN'",ORG,17,Soccer team,False,True,False,False
+test,44,"[260, 268): 'Mercedes'",MISC,Tag,"[260, 268): 'Mercedes'",ORG,15,brand,False,True,False,False
+test,45,"[1361, 1366): 'Czech'",LOC,Tag,"[1361, 1366): 'Czech'",MISC,17,,False,True,False,False
+test,49,"[31, 39): 'S.AFRICA'",MISC,Tag,"[31, 39): 'S.AFRICA'",LOC,16,,True,True,False,False
+test,49,"[57, 63): 'DURBAN'",PER,Tag,"[57, 63): 'DURBAN'",LOC,16,city,True,True,True,False
+test,50,"[1262, 1267): 'Czech'",LOC,Tag,"[1262, 1267): 'Czech'",MISC,17,,False,True,False,False
+test,50,"[1838, 1843): 'Czech'",LOC,Tag,"[1838, 1843): 'Czech'",MISC,17,,False,True,False,False
+test,50,"[190, 195): 'Czech'",LOC,Tag,"[190, 195): 'Czech'",MISC,17,,False,True,False,False
+test,50,"[93, 98): 'Czech'",LOC,Tag,"[93, 98): 'Czech'",MISC,17,,False,True,False,False
+test,52,"[1006, 1011): 'Czech'",LOC,Tag,"[1006, 1011): 'Czech'",MISC,17,,False,True,False,False
+test,52,"[1400, 1405): 'Czech'",LOC,Tag,"[1400, 1405): 'Czech'",MISC,17,,False,True,False,False
+test,52,"[766, 771): 'Czech'",LOC,Tag,"[766, 771): 'Czech'",MISC,17,,False,True,False,False
+test,53,"[1020, 1024): 'Nazi'",MISC,Tag,"[1020, 1024): 'Nazi'",ORG,13,CHECK: revisit. Should these be combined? I lef them separate to minimize changes,False,True,False,False
+test,54,"[1145, 1152): 'Boxmeer'",PER,Token,"[1141, 1152): 'van Boxmeer'",,17,,False,True,False,False
+test,54,"[11, 27): 'INTERVIEW-ZYWIEC'",MISC,Token,"[21, 27): 'ZYWIEC'",ORG,17,,True,True,False,False
+test,54,"[2499, 2504): 'Czech'",LOC,Tag,"[2499, 2504): 'Czech'",MISC,17,,False,True,False,False
+test,54,"[2594, 2601): 'Boxmeer'",PER,Token,"[2590, 2601): 'van Boxmeer'",,17,,False,True,False,False
+test,54,"[2654, 2659): 'Czech'",LOC,Tag,"[2654, 2659): 'Czech'",MISC,17,,False,True,False,False
+test,54,"[2903, 2908): 'Czech'",LOC,Tag,"[2903, 2908): 'Czech'",MISC,17,,False,True,False,False
+test,54,"[3224, 3230): 'Zywiec'",ORG,Span,"[3224, 3241): 'Zywiec Full Light'",ORG,14,beer brand,True,False,False,False
+test,54,"[3421, 3428): 'Boxmeer'",PER,Token,"[3417, 3428): 'van Boxmeer'",,17,,False,True,False,False
+test,54,"[3421, 3428): 'Boxmeer'",,Span,"[3417, 3428): 'van Boxmeer'",PER,9,,True,False,False,False
+test,54,,,Token,"[?, 27): 'ZYWIEC'",ORG,,INTERVIEW-ZYWIECï¿½SEES NO BIG 97 NET RISE.,False,True,False,True
+test,54,"[3231, 3241): 'Full Light'",MISC,Wrong,,,16,"See previous line – type of beer, brand",True,False,False,False
+test,55,"[129, 134): 'Czech'",LOC,Tag,"[129, 134): 'Czech'",MISC,17,,False,True,False,False
+test,56,"[11, 16): 'UK-US'",MISC,Token,"[11, 13): 'UK'",LOC,15,,False,True,False,False
+test,56,"[11, 16): 'UK-US'",MISC,Token,"[14, 16): 'US'",LOC,,,False,False,False,True
+test,61,,,Missing,"[11, 14): 'Med'",MISC,,"Abbreviation for ""Mediterranean""",False,False,False,True
+test,61,,,Missing,"[1550, 1553): 'Med'",MISC,,"Short for ""Mediterranean""",False,True,True,True
+test,61,"[395, 400): 'Genoa'",ORG,Tag,"[395, 400): 'Genoa'",LOC,17,,False,True,False,False
+test,61,,,Missing,"[79, 92): 'Mediterranean'",MISC,13,,True,True,False,False
+test,61,,,Missing,"[898, 901): 'Med'",MISC,8,"Abbreviation for ""Mediterranean""",True,False,False,False
+test,63,"[148, 160): 'Conservative'",MISC,Tag,"[148, 160): 'Conservative'",ORG,16,political party,True,False,False,False
+test,63,"[19, 39): 'office-Conservatives'",MISC,Token,"[26, 39): 'Conservatives'  ",ORG,14,political party,True,False,False,False
+test,63,"[19, 39): 'office-Conservatives'",MISC,Token,"[27, 39): 'Conservatives'",ORG,14,conservative party,False,True,False,False
+test,67,"[682, 690): 'Manitoba'",ORG,Tag,"[682, 690): 'Manitoba'",MISC,8,"""Manitoba Government Price Index""",True,False,False,False
+test,68,"[11, 19): 'Canadian'",MISC,Span,"[11, 30): 'Canadian West Coast'",LOC,17,"Ambiguous: Could be two entities (""Canadian"" and ""West Coast"")",False,True,False,False
+test,68,"[157, 165): 'Canadian'",MISC,Span,"[157, 176): 'Canadian West Coast'",LOC,17,"Ambiguous: Could be two entities (""Canadian"" and ""West Coast"")",False,True,False,False
+test,68,,,Missing,"[166, 176): 'West Coast'",LOC,,"Corpus *does* flag ""Canadian"" as MISC",True,True,False,True
+test,68,,,Missing,"[20, 30): ' West Coast'",LOC,,abstract ``places'' (e.g. {\it the free world}),False,False,False,True
+test,68,,,Missing,"[224, 234): 'West Coast'",LOC,,,True,True,True,True
+test,68,,,Missing,"[335, 345): 'East Coast'",LOC,,,True,True,True,True
+test,68,,,Missing,"[48, 51): 'CWB'",ORG,12,Canadian Wheat Board,True,False,False,False
+test,70,"[177, 197): 'New York Commodities'",ORG,Span,"[177, 202): 'New York Commodities Desk'",ORG,17,,True,True,False,False
+test,71,"[153, 173): 'New York Commodities'",ORG,Span,"[153, 178): 'New York Commodities Desk'",ORG,17,,True,True,False,False
+test,71,,,Missing,"[89, 107): 'WESTERN HEMISPHERE'",LOC,10,Example in training set of exactly the same entity tagged LOC,True,False,True,False
+test,72,"[154, 167): 'MEDITERRANEAN'",MISC,Tag,"[154, 167): 'MEDITERRANEAN'",LOC,17,Mediterannian = shortening of mediteranian ocean,False,True,False,False
+test,72,"[288, 294): 'Bajaia'",LOC,Tag,"[288, 294): 'Bajaia'",ORG,17,company? ,False,True,False,False
+test,72,,,Missing,"[78, 85): 'MIDEAST'",LOC,14,,True,False,True,False
+test,73,"[11, 14): 'NYC'",MISC,Tag,"[11, 14): 'NYC'",LOC,16,,False,True,False,False
+test,75,"[1438, 1444): 'Busang'",ORG,Tag,"[1438, 1444): 'Busang'",LOC,17,Location of ore deposit. We need to check elsewhere that this is labelled correctly ,False,True,False,False
+test,75,"[1438, 1444): 'Busang'",ORG,Span,"[1438, 1444): 'Busang'",,,Indonesia'sÊBusangÊvast gold deposit,False,False,True,True
+test,75,"[2736, 2752): 'Newmont-Santa Fe'",MISC,Token,"[2736, 2743): 'Newmont'",ORG,,Token error between two companies in a deal,False,False,False,True
+test,75,"[2736, 2752): 'Newmont-Santa Fe'",MISC,Token,"[2744, 2752): 'Santa Fe'",ORG,15,Token error between two companies in a deal,False,True,False,False
+test,75,"[2890, 2898): 'Santa Fe'",LOC,Tag,"[2890, 2898): 'Santa Fe'",ORG,17,,True,True,True,False
+test,75,"[36, 44): 'Santa Fe'",LOC,Tag,"[36, 44): 'Santa Fe'",ORG,17,Santa fe mining co.,True,True,True,False
+test,78,,,Missing,"[3425, 3431): 'Masisi'",LOC,,,True,True,True,True
+test,82,"[1178, 1184): 'Yakoma'",MISC,Tag,"[1178, 1184): 'Yakoma'",ORG,15,Tribe name ,False,True,False,False
+test,87,,,Missing,"[148, 159): 'Polish-born'",MISC,,,False,True,True,True
+test,88,,,Missing,"[1628, 1637): 'Far North'",LOC,,,True,True,True,True
+test,90,"[1129, 1140): 'Warsaw Pact'",MISC,Tag,"[1129, 1140): 'Warsaw Pact'",ORG,17,,False,True,False,False
+test,93,,,Missing,"[502, 509): 'Ottoman'",MISC,,"Treat ""Ottoman"" and ""Turkish"" as two separate MISC entities",False,False,True,True
+test,93,"[510, 517): 'Turkish' 	",,Span,"[502, 517): 'Ottoman Turkish'",MISC,,"""Ottoman turkey"" is an entity ",False,True,False,True
+test,94,"[331, 339): 'Budapest'",LOC,Span,"[331, 339): 'Budapest Bank’s'",ORG,14,bank name,True,False,False,False
+test,94,"[331, 339): 'Budapest'",LOC,Both,"[331, 344): 'Budapest Bank'",ORG,17,,False,True,False,False
+test,95,"[1656, 1665): 'Santander'",LOC,Tag,"[1656, 1665): 'Santander'",ORG,,,False,True,True,True
+test,100,"[56, 64): 'SANTIAGO'",PER,Tag,"[56, 64): 'SANTIAGO'",LOC,,,True,True,True,True
+test,100,"[941, 948): 'Chilean'",MISC,Both,"[941, 957): 'Chilean Congress'",ORG,10,,True,False,False,False
+test,100,,,Missing,"[949, 957): 'Congress'",ORG,,,False,True,True,True
+test,100,,,Missing,"[987, 995): 'Congress'",ORG,,,True,True,True,True
+test,103,"[193, 220): 'Ranyon (Rangoon) University'",ORG,Tag,"[193, 220): 'Ranyon (Rangoon) University'",LOC,15,,True,False,False,False
+test,103,"[794, 812): 'Rangoon University'",ORG,Tag,"[794, 812): 'Rangoon University'",LOC,,,False,False,False,True
+test,105,,,Missing,"[740, 748): 'Hansenne'",PER,,,True,True,True,True
+test,108,"[1510, 1527): 'Christian-Shi'ite'",MISC,Span,"[1510, 1534): 'Christian-Shi'ite Moslem'",MISC,15,all describes one force of people,True,False,False,False
+test,108,"[59, 75): 'Haitham Haddadin'",ORG,Tag,"[59, 75): 'Haitham Haddadin'",PER,17,,True,True,True,False
+test,108,"[1528, 1534): 'Moslem'",Misc,Wrong,,,,,False,False,False,True
+test,112,"[1560, 1581): 'U.S. Court of Appeals'",ORG,Span,"[1547, 1581): '11th Circuit U.S. Court of Appeals'",,,,False,False,True,True
+test,112,"[174, 184): 'John Mills'",PER,Span,"[174, 187): 'John Mills Jr'",PER,16,,True,False,False,False
+test,112,"[174, 184): 'John Mills'",,Span,"[174, 187): 'John Mills Jr'",,16,,True,True,False,False
+test,114,"[11, 17): 'Iowa-S'",LOC,Token,"[11, 15): 'Iowa'",LOC,,"""Iowa-S"" treated as a single token",False,False,False,True
+test,114,"[11, 17): 'Iowa-S'",LOC,Token,"[11, 15): 'Iowa'  ",,14,split on ‘-’,True,False,False,False
+test,114,"[18, 22): 'Minn'",LOC,Span,"[16, 22): 'S Minn'",,,,False,False,False,True
+test,114,"[51, 61): 'sales-USDA'",MISC,Token,"[57, 61): 'USDA'",MISC,17,,False,True,False,False
+test,115,,,Missing,"[459, 465): 'Luebke'",PER,,,True,True,True,True
+test,117,,,Missing,"[1270, 1273): 'Hub'",LOC,8,Henry Hub,True,False,False,False
+test,117,,,Missing,"[2227, 2236): 'Southwest'",LOC,,,True,True,True,True
+test,118,"[127, 136): 'St. Louis'",LOC,Both,"[127, 155): 'St. Louis Merchants Exchange'",ORG,17,"Ambiguous: Location, but also a company I think? ",False,True,False,False
+test,118,"[127, 136): 'St. Louis'",LOC,Span,"[127, 155): 'St. Louis Merchants Exchange'",ORG ,,"A building in St. Louis. However it is also a company, and I believe that in this case it is the company being referred to ",False,True,False,True
+test,118,"[535, 550): 'mid-Mississippi'",MISC,Tag,"[535, 550): 'mid-Mississippi'",LOC,17,,True,True,False,False
+test,118,"[552, 560): 'McGregor'",PER,Tag,"[552, 560): 'McGregor'",LOC,17,,False,True,False,False
+test,118,"[552, 560): 'McGregor'  ",PER,Tag,"[552, 560): 'McGregor'  ",LOC,,is a city on the Mississippi River,False,False,False,True
+test,118,"[776, 791): 'mid-Mississippi'",MISC,Tag,"[776, 791): 'mid-Mississippi'",LOC,17,,False,True,False,False
+test,118,"[776, 791): 'mid-Mississippi'  ",MISC,Tag,"[776, 791): 'mid-Mississippi'  ",LOC,,location where barge is,False,False,False,True
+test,121,,,Missing,"[11, 29): 'Action Performance'",ORG,,,False,True,False,True
+test,122,"[273, 286): 'United States'",LOC,Both,"[251, 286): 'Human Society of the United States'",ORG,8,,True,False,False,False
+test,122,"[522, 545): 'Glencoe Animal Hospital'",ORG,Tag,"[522, 545): 'Glencoe Animal Hospital'",LOC,15,specific hospitol,True,False,False,False
+test,123,"[11, 17): 'Iowa-S'",LOC,Token,"[11, 15): 'Iowa'  ",,15,split on '-',True,False,False,False
+test,123,"[18, 22): 'Minn'",LOC,Span,"[16, 22): 'S Minn'",,,,False,False,False,True
+test,127,"[528, 531): 'RAI'",LOC,Tag,"[528, 531): 'RAI'",ORG,17,,False,True,False,False
+test,130,"[389, 395): 'Europe'",LOC,Both,"[389, 405): 'Europe Agreement'",MISC,17,,False,True,False,False
+test,131,,,Missing,"[449, 454): 'Babri'",LOC,,the Babri mosque,True,False,True,True
+test,131,,,Missing,"[449, 461): 'Babri mosque'",LOC,,https://en.wikipedia.org/wiki/Babri_Masjid,False,True,False,True
+test,134,"[62, 73): 'Lantau Peak'",MISC,Tag,"[62, 73): 'Lantau Peak'",LOC,15,??? def a peak,True,False,False,False
+test,136,"[647, 657): 'Treasuries'",MISC,Wrong,,,16,"??? ""Returns on Treasuries"".. talking about investments but is capitolized",True,False,False,False
+test,137,"[313, 324): 'Bonny Light'",MISC,Tag,"[313, 324): 'Bonny Light'",ORG,16,brand? ,False,True,False,False
+test,137,"[341, 354): 'Arabian Light'",MISC,Tag,"[341, 354): 'Arabian Light'",ORG,16,Brand? ,False,True,False,False
+test,140,,,Missing,"[1565, 1581): 'Arafat-Netanyahu'",MISC,,"It's an adjective used to describe the relation/time period between 2 people, hence the tag is MISC",True,True,True,True
+test,142,"[342, 348): 'Kesers'",PER,Tag,"[342, 348): 'Kesers'",MISC,17,Two rival clans ,False,True,False,False
+test,142,"[353, 363): 'Karabuluts'",PER,Tag,"[353, 363): 'Karabuluts'",ORG,14,Clan name ,False,True,False,False
+test,146,"[11, 17): 'ACCESS'",MISC,Tag,"[11, 17): 'ACCESS'",ORG,17,Short fo NYMEX ACCESS,False,True,False,False
+test,146,"[143, 155): 'NYMEX ACCESS'",MISC,Tag,"[143, 155): 'NYMEX ACCESS'",ORG,17,Stock market ,False,True,False,False
+test,146,"[62, 73): 'LOS ANGELES'",ORG,Tag,"[62, 73): 'LOS ANGELES'",LOC,8,,True,False,False,False
+test,146,"[632, 638): 'ACCESS'",MISC,Tag,"[632, 638): 'ACCESS'",ORG,17,Short fo NYMEX ACCESS,False,True,False,False
+test,148,"[314, 335): 'St Pius X High School'",ORG,Tag,"[314, 335): 'St Pius X High School'",LOC,14,specific high school in abq,True,False,False,False
+test,149,"[1504, 1520): 'Consumer Project'",PER,Both,"[1504, 1534): 'Consumer Project on Technology'",ORG,17,,True,True,True,False
+test,149,,,Missing,"[2650, 2653): 'Net'",MISC,,"Capitalized and short for ""Internet"", which is tagged MISC throughout this document",False,False,False,True
+test,149,,,Missing,"[902, 909): 'Western'",MISC,,,True,True,True,True
+test,149,"[2894, 2902): 'Internet'",MISC,Wrong,,,16,,False,True,False,False
+test,149,"[2233, 2241): 'Internet'",MISC,Wrong,,,16,,False,True,False,False
+test,149,"[3687, 3694): 'Network'",MISC,Wrong,,,14,“Network operators…” ref to internet?,True,False,False,False
+test,149,"[3340, 3348): 'Internet'",MISC,Wrong,,,14,,False,True,False,False
+test,149,"[1100, 1108): 'Internet'",MISC,Wrong,,,14,,False,True,False,False
+test,149,"[155, 163): 'Internet'",MISC,Wrong,,,,,False,False,False,True
+test,149,"[2448, 2456): 'Internet'",MISC,Wrong,,,,,False,False,False,True
+test,149,"[3905, 3913): 'Internet'",MISC,Wrong,,,,,False,False,False,True
+test,149,"[3516, 3524): 'Internet'",MISC,Wrong,,,,,False,False,False,True
+test,149,"[3240, 3248): 'Internet'",MISC,Wrong,,,,,False,False,False,True
+test,152,"[1035, 1041): 'League'",LOC,Tag,"[1035, 1041): 'League'",ORG,17,Zach: short for a political group; Fred: Northern League,True,True,False,False
+test,152,"[1487, 1489): 'Po'",LOC,Span,"[1487, 1495): 'Po River'",LOC,16,,True,False,False,False
+test,152,,,Missing,"[321, 327): 'Mantua'",LOC,,,True,True,True,True
+test,152,,,Missing,"[61, 67): 'MANTUA'",LOC,,,True,True,True,True
+test,152,"[556, 559): 'Let'",LOC,Wrong,,,17,,True,True,False,False
+test,153,,,Missing,"[21, 31): 'Radiometer'",ORG,,,True,True,True,True
+test,153,"[229, 238): 'Wednesday'",ORG,Wrong,,,17,,True,True,False,False
+test,155,"[423, 430): 'Antwerp'",ORG,Tag,"[423, 430): 'Antwerp'",LOC,17,,True,True,True,False
+test,155,"[776, 783): 'Antwerp'",ORG,Tag,"[776, 783): 'Antwerp'",LOC,17,,True,True,True,False
+test,158,"[69, 79): 'Muenchener'",MISC,Tag,"[69, 101): 'Muenchener Rueckversicherungs AG'",ORG,17,,False,True,False,False
+test,158,"[80, 101): 'Rueckversicherungs AG'  ",ORG,Span,"[69, 101): 'Muenchener Rueckversicherungs AG'",,,insurance company,False,False,False,True
+test,158,"[69, 79): 'Muenchener'",MISC,Wrong,,,16,,True,False,False,False
+test,161,"[11, 24): 'John Lewis UK'",ORG,Span,"[11, 21): 'John Lewis UK'",ORG,,,False,False,False,True
+test,161,"[11, 24): 'John Lewis UK'",ORG,Span,"[11, 21): 'John Lewis'",ORG,15,"??? division of company based in UK, should UK be separate?",True,False,False,False
+test,161,"[11, 24): 'John Lewis UK'",ORG,Both,"[22, 24): 'UK'",LOC,,,False,False,False,True
+test,161,"[76, 86): 'John Lewis'",PER,Tag,"[76, 86): 'John Lewis'",ORG,17,company with name John Lewis ,False,True,False,False
+test,161,"[76, 86): 'John Lewis'",PER,Both,"[76, 98): 'John Lewis Partnership'",ORG,,,False,True,True,True
+test,163,"[121, 133): 'Conservative'",MISC,Tag,"[121, 133): 'Conservative'",ORG,15,political party,True,False,False,False
+test,163,,,Missing,"[411, 424): 'Conservatives'",MISC,,,False,False,True,True
+test,166,"[41, 43): 'NZ'",LOC,Both,"[41, 49): 'NZ First'",ORG,,,True,True,True,True
+test,167,"[28, 31): 'Nat'",PER,Tag,"[28, 31): 'Nat'",ORG,7,New Zealand National Party,True,False,False,False
+test,167,"[33, 36): 'Lab'",PER,Tag,"[33, 36): 'Lab'",ORG,,New Zealand Labour Party,False,False,False,True
+test,168,,,Missing,"[1023, 1028): 'Labor'",ORG,,Reference to Australian Labor Party,False,True,True,True
+test,168,"[1040, 1046): 'Fraser'",PER,Tag,"[1040, 1046): 'Fraser'",LOC,17,Electoral Reigon ,False,True,False,False
+test,168,"[1346, 1354): 'Canberra'",LOC,Both,"[1346, 1361): 'Canberra Bureau'",ORG,,"""Bureau"" is capitalized",True,True,True,True
+test,168,"[429, 435): 'Fraser'",PER,Tag,"[429, 435): 'Fraser'",LOC,17,Electoral Reigon ,False,True,False,False
+test,168,"[443, 471): 'Australian Capital Territory'",MISC,Tag,"[443, 471): 'Australian Capital Territory'",LOC,17,Reigon ,True,True,True,False
+test,170,"[321, 329): 'Seagramd'",MISC,Span,"[321, 333): 'Seagramd ace'",MISC,14,"full vessel name, Ace should prob be cap",True,False,False,False
+test,170,"[627, 634): 'Bangkok'",MISC,Tag,"[627, 634): 'Bangkok'",LOC,17,,False,True,False,False
+test,173,,,Missing,"[278, 289): 'Port Office'",ORG,,,True,True,True,True
+test,176,,,Missing,"[2024, 2032): 'Ministry'",ORG,12,,True,False,False,False
+test,176,,,Missing,"[2276, 2284): 'Ministry'",ORG,11,"Reference to the Indonesian Mines and Energy Ministry. Single-word, but capitalized ""M""",True,False,False,False
+test,176,"[2419, 2425): 'Busang'",ORG,Tag,"[2419, 2425): 'Busang'",LOC,17,Location of gold mine ,False,True,False,False
+test,176,"[2732, 2738): 'Busang'",ORG,Tag,"[2732, 2738): 'Busang'",LOC,17,Location of gold mine ,False,True,False,False
+test,176,"[2779, 2794): 'PT Panutan Duta'",PER,Tag,"[2779, 2794): 'PT Panutan Duta'",ORG,17,,True,True,True,False
+test,176,"[2887, 2894): 'Panutan'",PER,Tag,"[2887, 2894): 'Panutan'",ORG,16,,False,True,False,False
+test,176,"[2960, 2966): 'Busang'",ORG,Tag,"[2960, 2966): 'Busang'",LOC,15,,True,False,False,False
+test,176,"[57, 67): 'K.T. Arasu'",LOC,Tag,"[57, 67): 'K.T. Arasu'",PER,17,,True,True,False,False
+test,177,"[11, 19): 'Honda RV'",MISC,Span,"[11, 16): 'Honda'",,,,False,False,True,True
+test,177,"[11, 19): 'Honda RV'",MISC,Both,"[11, 16): 'Honda'",ORG,9,"Article is about a single type of RV made by Honda Motor Co. ""RV"" is a generic term in this context. ""Honda"" used as an adjective",True,False,False,False
+test,178,"[1787, 1794): 'Uruguay'",LOC,Both,"[1787, 1800): 'Uruguay Round'",MISC,17,"Zach: Ambiguous; Fred: I think the Uruguay Round qualifies as an ""event"" and should be tagged MISC; see https://en.wikipedia.org/wiki/Uruguay_Round",False,True,False,False
+test,178,,,Missing,"[2272, 2276): 'West'",LOC,13,"""the West""",True,False,False,False
+test,178,"[951, 960): 'then-U.S.'",MISC,Token,"[956, 960): 'U.S.'",LOC,17,,False,True,False,False
+test,179,,,Missing,"[594, 622): 'Posts and Telecommunications'",ORG,,Japanese government ministry,False,True,True,True
+test,180,"[216, 220): 'BILO'",MISC,Tag,"[216, 220): 'BILO'",ORG,15,??? chain of discount stores,True,True,False,False
+test,180,"[259, 263): 'BILO'",MISC,Tag,"[259, 263): 'BILO'",ORG,17,A store chain ,True,True,False,False
+test,180,"[395, 399): 'BILO'",MISC,Tag,"[395, 399): 'BILO'",ORG,17,Store chain ,True,True,False,False
+test,180,"[450, 454): 'TOPS'",MISC,Tag,"[450, 454): 'TOPS'",ORG,17,Brand,True,True,False,False
+test,180,"[579, 583): 'TOPS'",MISC,Tag,"[579, 583): 'TOPS'",ORG,16,,True,True,False,False
+test,180,"[588, 592): 'BILO'",MISC,Tag,"[588, 592): 'BILO'",ORG,17,Brand,True,True,False,False
+test,183,"[18, 35): 'SKIING-GLADISHIVA'",MISC,Token,"[25, 35): 'GLADISHIVA'",PER,17,,True,True,True,False
+test,184,"[394, 398): 'LPGA'",ORG,Both,"[394, 404): 'LPGA Tours'",MISC,8,,True,False,False,False
+test,184,"[633, 637): 'U.S.'",LOC,Both,"[633, 645): 'U.S. Amateur'",MISC,,United States Amateur Championship,False,True,False,True
+test,186,"[1275, 1283): 'Florence'",LOC,Both,"[1275, 1291): 'Florence Masnada'",PER,,,False,True,False,True
+test,186,"[1284, 1291): 'Masnada'",PER,Wrong,"[1275, 1291): 'Florence Masnada'",,17,Combined with above,False,True,False,False
+test,186,"[1284, 1291): 'Masnada'",PER,Span,"[1275, 1291): 'Florence Masnada'  ",PER,16,,True,False,False,False
+test,186,,,Token,"[1398, 1405): 'Austria'",LOC,,Tokenizer treated 'Austria)118' as a single token,False,False,True,True
+test,186,"[432, 446): 'Ingeborg Helen'",PER,Span,"[432, 454): 'Ingeborg Helen Markein'",PER,17,,True,True,False,False
+test,186,"[432, 446): 'Ingeborg Helen'",,Span,"[432, 454): 'Ingeborg Helen Markein'",,15,,True,True,False,False
+test,186,"[533, 541): 'Florence'",LOC,Both,"[533, 549): 'Florence Masnada'",PER,,,False,True,False,True
+test,186,"[542, 549): 'Masnada'",PER,Wrong,"[533, 549): 'Florence Masnada'",,17,Combined with above,False,True,False,False
+test,186,"[542, 549): 'Masnada'",PER,Span,"[533, 549): 'Florence Masnada'  ",PER,16,,True,False,False,False
+test,186,"[1275, 1283): 'Florence'",LOC,Wrong,,,,,False,False,True,True
+test,186,"[533, 541): 'Florence'",LOC,Wrong,,,,,False,False,True,True
+test,186,"[1607, 1614): 'Super G'",MISC,Wrong,,,17,"Fred: Short for ""super giant slalom"", which is a generic term for an event; also, the ""super g"" is mentioned elsewhere in the same doc and not tagged there",False,True,False,False
+test,186,"[533, 541): 'Florence'  ",LOC,Wrong,,,,,False,False,False,True
+test,187,"[1173, 1179): 'Germay'",,Missing,"[1173, 1179): 'Germay'",LOC ,,Misspelling of Germany,False,True,False,True
+test,187,,,Missing,"[1173, 1179): 'Germay'",LOC,11,,True,False,False,False
+test,188,"[18, 34): 'SKIING-WORLD CUP'",MISC,Token,"[25, 34): 'WORLD CUP'",,17,,False,True,False,False
+test,190,"[11, 27): 'BOBSLEIGH-SHIMER'",MISC,Token,"[21, 27): 'SHIMER'",PER,16,,False,True,False,False
+test,190,"[440, 445): 'Italy'",LOC,Both,"[440, 447): 'Italy I'",ORG,16,THIS IS A REPEAT WHATS HAPPENING ,False,True,False,False
+test,190,"[440, 445): 'Italy'  ",LOC,Span,"[440, 447): 'Italy I'  ",ORG,,bobsled division,False,False,False,True
+test,190,"[11, 27): 'BOBSLEIGH-SHIMER'",MISC,Token,,,16,,True,False,False,False
+test,191,"[11, 25): 'SKIING-CHINESE'",MISC,Token,"[18, 25): 'CHINESE'",ORG,17,,False,True,False,False
+test,192,"[11, 30): 'BOBSLEIGH-WORLD CUP'",MISC,Token,"[21, 30): 'WORLD CUP'",,17,,False,True,False,False
+test,192,"[808, 815): 'Garrett'",PER,Sentence,"[808, 821): 'Garrett Hines'",PER,,Sentence boundary between first and last name,False,True,True,True
+test,193,"[744, 759): 'United Province'",LOC,Tag,"[744, 759): 'United Province'",ORG,17,"Fred: Somewhat ambiguous, but appears to refer to the United Province cricket team",False,True,False,False
+test,194,"[21, 37): 'SKIING-WORLD CUP'",MISC,Token,"[28, 37): 'WORLD CUP'",,16,,False,True,False,False
+test,195,"[21, 37): 'SKIING-WORLD CUP'",MISC,Token,"[28, 37): 'WORLD CUP'",MISC,,"Tokenizer treated ""SKIING-WORLD"" as a single token",False,False,True,True
+test,199,"[108, 124): 'Scottish premier'",MISC,Span,"[108, 116): 'Scottish'",MISC,,Divisions of leagues not considered entities,True,True,True,True
+test,199,"[108, 124): 'Scottish premier'",,Span,"[108, 116): 'Scottish'",,16,"Ambiguous: Divisions of leagues not entities, but ""Scottish premier"" could be seen as a term derived from a location",True,False,False,False
+test,199,"[108, 124): 'Scottish premier'",MISC,Span,"[108, 133): 'Scottish premier division'",MISC,17,,False,True,False,False
+test,199,"[27, 52): 'SCOTTISH PREMIER DIVISION'",MISC,Span,"[27, 35): 'SCOTTISH'",MISC,16,,True,False,False,False
+test,199,"[491, 498): 'Winters'",PER,Sentence,"[484, 498): 'Robert Winters'",PER,,Sentence boundary between first and last names,False,True,True,True
+test,199,"[484, 490): 'Robert'",PER,Sentence,"[484, 498): 'Robert Winters'",,17,,False,True,False,False
+test,200,"[288, 293): 'Villa'",ORG,Sentence,"[282, 293): 'Aston Villa'",ORG,,Sentence boundary between first and last names,True,True,True,True
+test,200,"[282, 287): 'Aston'",ORG,Sentence,"[282, 293): 'Aston Villa'",,17,,False,True,False,False
+test,200,"[335, 344): 'Wimbledon'",LOC,Tag,"[335, 344): 'Wimbledon'",ORG,,Soccer team,False,True,True,True
+test,200,"[390, 399): 'Wimbledon'",LOC,Tag,"[390, 399): 'Wimbledon'",ORG,,Soccer team,False,True,True,True
+test,200,"[445, 454): 'Wimbledon'",LOC,Tag,"[445, 454): 'Wimbledon'",ORG,,Soccer team,False,True,True,True
+test,200,"[479, 484): 'Chris'",PER,Sentence,"[479, 491): 'Chris Sutton'",PER,,Sentence boundary between first and last names,False,True,True,True
+test,202,,,Missing,"[24, 31): 'BRITISH'",MISC,16,,True,True,True,False
+test,202,"[11, 22): 'RUGBY UNION'",ORG,Wrong,,,,https://en.wikipedia.org/wiki/Rugby_union,False,False,False,True
+test,203,,,Missing,"[214, 221): 'Windass'",PER,,,True,True,True,True
+test,204,"[283, 290): 'Wallaby'",ORG,Tag,"[283, 290): 'Wallaby'",MISC,,"""aï¿½Wallabyï¿½jersey"" --> Team name as adjective",False,True,False,True
+test,204,,,Missing,"[717, 725): 'Super 12'",MISC,,https://en.wikipedia.org/wiki/Super_Rugby,False,True,True,True
+test,205,"[627, 636): 'Wimbledon'",LOC,Tag,"[627, 636): 'Wimbledon'",ORG,,,True,True,True,True
+test,207,"[1041, 1047): 'Oxford'",LOC,Tag,"[1041, 1047): 'Oxford'",ORG,,Soccer team,True,True,True,True
+test,207,"[1304, 1314): 'Portsmouth'",Loc,Tag,"[1304, 1314): 'Portsmouth'",ORG,16,Soccer team,True,False,False,False
+test,207,"[1304, 1314): 'Portsmouth'",LOC,Tag,"[1304, 1314): 'Portsmouth'",ORG,17,,True,True,False,False
+test,209,"[384, 388): 'East'",ORG,Sentence,"[384, 393): 'East Fife'",ORG,,"Sentence boundary between ""East"" and ""Fife""",False,True,True,True
+test,211,"[54, 61): 'WALLABY'",LOC,Tag,"[54, 61): 'WALLABY'",ORG,16,Team,False,True,False,False
+test,213,"[451, 455): 'Mark'",PER,Sentence,"[451, 463): 'Mark Murless'",PER,,Sentence boundary between first and last names,True,True,True,True
+test,213,"[525, 530): 'Merwe'",PER,Sentence,"[510, 530): 'Schalk van der Merwe'",PER,,Sentence boundary between first and last names,True,True,True,True
+test,213,"[510, 524): 'Schalk van der'",PER,Sentence,"[510, 530): 'Schalk van der Merwe'",,17,,False,True,False,False
+test,213,"[696, 700): 'Dion'",PER,Sentence,"[696, 707): 'Dion Fourie'",PER,,Sentence boundary between first and last names,True,True,True,True
+test,214,"[243, 262): 'Saturday'sWorld Cup'",MISC,Token,"[253, 262): 'World Cup'",MISC,,"Tokenizer treated ""Saturday'sWorld"" as a single token",False,False,False,True
+test,214,"[292, 308): 'Northern Ireland'",LOC,Tag,"[292, 308): 'Northern Ireland'",ORG,,Soccer team,False,False,False,True
+test,214,"[30, 37): 'ALBANIA'",LOC,Tag,"[30, 37): 'ALBANIA'",ORG,14,Team,False,True,False,False
+test,214,"[351, 358): 'Albania'",LOC,Tag,"[351, 358): 'Albania'",ORG,,Soccer team,False,False,False,True
+test,214,"[474, 481): 'Albania'",LOC,Tag,"[474, 481): 'Albania'",ORG,,Soccer team,False,False,False,True
+test,214,"[58, 67): 'N.IRELAND'",LOC,Tag,"[58, 67): 'N.IRELAND'",ORG,,Soccer team,False,False,False,True
+test,215,"[1035, 1043): 'Victoria'",LOC,Tag,"[1035, 1043): 'Victoria'",ORG,,Cricket team,False,False,False,True
+test,215,"[161, 169): 'Victoria'",LOC,Tag,"[161, 169): 'Victoria'",ORG,,Cricket team,False,False,True,True
+test,215,"[310, 318): 'Victoria'",LOC,Tag,"[310, 318): 'Victoria'",ORG,,Cricket team,False,True,True,True
+test,215,"[987, 991): 'Pace'",PER,Wrong,,,17,Fred: https://en.wikipedia.org/wiki/Pace_bowling,True,True,False,False
+test,216,"[20, 36): 'SHEFFIELD SHIELD'",MISC,Tag,"[20, 36): 'SHEFFIELD SHIELD'",ORG,17,,False,True,False,False
+test,217,"[19, 30): 'SOUTH KOREA'",LOC,Tag,"[19, 30): 'SOUTH KOREA'",ORG,14,,False,True,False,False
+test,218,"[865, 877): 'Ironi Rishon'",ORG,Span,"[865, 884): 'Ironi Rishon Lezion'",,,,False,True,True,True
+test,219,"[109, 129): 'United Arab Emirates'",LOC,Tag,"[109, 129): 'United Arab Emirates'",ORG,7,,True,False,False,False
+test,219,"[132, 138): 'Kuwait'",LOC,Tag,"[132, 138): 'Kuwait'",ORG,8,Soccer team,True,False,False,False
+test,219,"[165, 168): 'UAE'",LOC,Tag,"[165, 168): 'UAE'",ORG,,Soccer team,False,False,False,True
+test,219,"[223, 229): 'Kuwait'",LOC,Tag,"[223, 229): 'Kuwait'",ORG,,Soccer team,False,False,False,True
+test,219,"[274, 285): 'South Korea'",LOC,Tag,"[274, 285): 'South Korea'",ORG,,Soccer team,False,False,False,True
+test,219,"[288, 297): 'Indonesia'",LOC,Tag,"[288, 297): 'Indonesia'",ORG,8,Soccer team,True,False,False,False
+test,219,"[315, 326): 'South Korea'",LOC,Tag,"[315, 326): 'South Korea'",ORG,,Soccer team,False,False,False,True
+test,219,"[368, 371): 'Koo'",PER,Sentence,"[368, 381): 'Koo Jeon Woon'",PER,,"Sentence boundary between ""Koo"" and ""Jeon Woon""",False,True,True,True
+test,219,"[385, 394): 'Indonesia'",LOC,Tag,"[385, 394): 'Indonesia'",ORG,,Soccer team,False,False,False,True
+test,219,"[536, 547): 'South Korea'",LOC,Tag,"[536, 547): 'South Korea'",ORG,,Soccer team,False,False,False,True
+test,219,"[562, 565): 'UAE'",LOC,Tag,"[562, 565): 'UAE'",ORG,,,True,True,True,True
+test,219,"[580, 586): 'Kuwait'",LOC,Tag,"[580, 586): 'Kuwait'",ORG,16,team,False,True,False,False
+test,219,"[601, 610): 'Indonesia'",LOC,Tag,"[601, 610): 'Indonesia'",ORG,9,Soccer team,True,False,True,False
+test,220,"[1072, 1079): 'ATLANTA'",LOC,Tag,"[1072, 1079): 'ATLANTA'",ORG,15,Team,False,True,False,False
+test,220,"[1203, 1210): 'HOUSTON'",LOC,Tag,"[1203, 1210): 'HOUSTON'",ORG,13,team,False,True,False,False
+test,220,"[76, 95): 'National Basketball'",ORG,Sentence,"[76, 107): 'National Basketball Association'",ORG,,"Sentence boundary between ""Basketball"" and ""Association""",False,False,False,True
+test,220,"[92, 100): 'National'",ORG,Sentence,"[92, 123): 'National Basketball Association'",,17,,False,True,False,False
+test,220,"[415, 431): 'CENTRAL DIVISION'",MISC,Wrong,,,17,"Zach: CHECK: what do we do in cases like these. I'm leaving atlantic cause atlantic is a reigon, but divisions donÕt count Iirc; Fred: Dicisions of leagues not considered entities",False,True,False,False
+test,221,"[76, 95): 'National Basketball'",ORG,Sentence,"[76, 107): 'National Basketball Association'",,17,,False,True,False,False
+test,222,"[1108, 1118): 'NEW JERSEY'",LOC,Tag,"[1108, 1118): 'NEW JERSEY'",ORG,,Hockey team,False,False,False,True
+test,222,"[1130, 1136): 'BOSTON'",LOC,Tag,"[1130, 1136): 'BOSTON'",ORG,,Hockey team,False,False,False,True
+test,222,"[1148, 1156): 'HARTFORD'",LOC,Tag,"[1148, 1156): 'HARTFORD'",ORG,,Hockey team,False,False,False,True
+test,222,"[1171, 1183): 'NY ISLANDERS'",LOC,Tag,"[1171, 1183): 'NY ISLANDERS'",ORG,,Hockey team,True,True,True,True
+test,222,"[1195, 1203): 'MONTREAL'",LOC,Tag,"[1195, 1203): 'MONTREAL'",ORG,,Hockey team,False,False,False,True
+test,222,"[1218, 1225): 'TORONTO'",LOC,Tag,"[1218, 1225): 'TORONTO'",ORG,,Hockey team,False,False,False,True
+test,222,"[1237, 1247): 'PITTSBURGH'",LOC,Tag,"[1237, 1247): 'PITTSBURGH'",ORG,,Hockey team,False,False,False,True
+test,222,"[1260, 1271): 'LOS ANGELES'",LOC,Tag,"[1260, 1271): 'LOS ANGELES'",ORG,,Hockey team,False,False,False,True
+test,222,"[1285, 1293): 'SAN JOSE'",LOC,Tag,"[1285, 1293): 'SAN JOSE'",ORG,15,team,False,True,False,False
+test,222,"[1304, 1313): 'VANCOUVER'",LOC,Tag,"[1304, 1313): 'VANCOUVER'",ORG,,Hockey team,False,False,False,True
+test,222,"[92, 107): 'National Hockey'",ORG,Sentence,"[76, 98): 'National Hockey League'",ORG,,"Sentence boundary between ""Hockey"" and ""League""",False,True,False,True
+test,222,"[108, 114): 'League'",ORG,Sentence,"[92, 114): 'National Hockey League'",ORG,,"Sentence boundary between ""Hockey"" and ""League""",False,False,True,True
+test,222,"[92, 107): 'National Hockey'",ORG,Sentence,"[92, 114): 'National Hockey League'",,17,,True,True,False,False
+test,223,"[231, 243): 'Philadelphia'",LOC,Tag,"[231, 243): 'Philadelphia'",ORG,,,True,True,True,True
+test,223,"[246, 252): 'DALLAS'",LOC,Tag,"[246, 252): 'DALLAS'",ORG,,,True,True,True,True
+test,223,"[255, 263): 'St Louis'",LOC,Tag,"[255, 263): 'St Louis'",ORG,,,True,True,True,True
+test,223,"[266, 274): 'COLORADO'",LOC,Tag,"[266, 274): 'COLORADO'",ORG,,,True,True,True,True
+test,223,"[277, 285): 'EDMONTON'",LOC,Tag,"[277, 285): 'EDMONTON'",ORG,,,True,True,True,True
+test,223,"[288, 294): 'Ottawa'",LOC,Tag,"[288, 294): 'Ottawa'",ORG,,,True,True,True,True
+test,223,"[92, 98): 'League'",ORG,Sentence,"[76, 98): 'National Hockey League'",ORG,,"Sentence boundary between ""Hockey"" and ""League""",True,True,True,True
+test,223,"[76, 91): 'National Hockey'",ORG,Sentence,"[76, 98): 'National Hockey League'",,17,,True,True,False,False
+test,227,"[19, 25): 'BALKAN'",LOC,Tag,"[19, 25): 'BALKAN'",MISC,16,REPEAT -- Whats going on ,False,True,False,False
+test,227,"[99, 105): 'Balkan'",LOC,Tag,"[99, 105): 'Balkan'",MISC,17,,False,True,False,False
+test,228,"[771, 795): 'De Graafschap Doetinchem'",ORG,Tag,"[771, 795): 'De Graafschap Doetinchem'",LOC,17,,False,True,False,False
+test,229,"[703, 711): 'Sporting'",,Span,"[703, 717): 'Sporting Gijon'",,,,False,True,False,True
+test,229,"[703, 711): 'Sporting'",ORG,Span,"[703, 717): 'Sporting Gijon'",ORG,14,soccer team,True,False,False,False
+test,229,"[703, 711): 'Sporting'",ORG,Span,"[703,717): 'Sporting Gijon'",ORG,17,,False,True,False,False
+test ,186,"[1398, 1409): 'Austria)118'",,Token,"[1398, 1405): 'Austria'",LOC,,Token and Missing ,False,False,False,True
+train,6,"[121, 137): 'Toronto Dominion'",PER,Tag,"[121, 137): 'Toronto Dominion'",ORG,,TD Bank,False,True,True,True
+train,11,"[485, 491): 'Rajavi'",MISC,Tag,"[485, 491): 'Rajavi'",PER,,Massoud Rajavi,False,False,True,True
+train,29,"[459, 468): 'Mickelson'",,Sentence,"[454, 468): 'Phil Mickelson'",,,Sentence boundary between first and last name,False,True,False,True
+train,29,"[767, 774): 'O'Meara'",,Sentence,"[762, 774): 'Mark O'Meara'",,,Sentence boundary between first and last name,False,True,False,True
+train,29,"[886, 893): 'Shigeki'",PER,Sentence,"[886, 902): 'Shigeki Maruyama'",,,Sentence boundary between first and last name,False,False,True,True
+train,36,"[115, 134): 'County Championship'",MISC,Span,"[107, 134): 'English County Championship'",,,,False,True,False,True
+train,36,"[20, 47): 'ENGLISH COUNTY CHAMPIONSHIP'",MISC,Span,"[20, 27): 'ENGLISH'",MISC,,First sentence of article correctly separates these two entities,False,False,False,True
+train,36,"[20, 47): 'ENGLISH COUNTY CHAMPIONSHIP'",MISC,Span,"[28, 47): 'COUNTY CHAMPIONSHIP'",MISC,,First sentence of article correctly separates these two entities,False,False,False,True
+train,37,"[144, 151): 'England'",LOC,Tag,"[144, 151): 'England'",ORG,,Cricket team,False,False,False,True
+train,37,"[156, 164): 'Pakistan'",LOC,Tag,"[156, 164): 'Pakistan'",ORG,,Cricket team,False,False,False,True
+train,37,"[190, 197): 'England'",LOC,Tag,"[190, 197): 'England'",ORG,,Cricket team,False,False,False,True
+train,37,"[20, 27): 'ENGLAND'",LOC,Tag,"[20, 27): 'ENGLAND'",ORG,,Cricket team,False,False,False,True
+train,37,"[30, 38): 'PAKISTAN'",LOC,Tag,"[30, 38): 'PAKISTAN'",ORG,,Cricket team,False,False,False,True
+train,37,"[842, 846): 'Khan'",PER,Sentence,"[837, 846): 'Moin Khan'",,,Sentence boundary between first and last name,False,True,True,True
+train,41,"[370, 378): 'Republic'",LOC,Sentence,"[364, 378): 'Czech Republic'",,,"Sentence boundary between ""Czech"" and ""Republic""",False,True,True,True
+train,42,"[200, 206): 'Millns'",MISC,Tag,"[200, 206): 'Millns'",PER,,,False,False,True,True
+train,42,"[234, 241): 'England'",LOC,Both,"[234, 243): 'England A'",ORG,,Cricket team,False,False,False,True
+train,43,"[2111, 2117): 'Batumi'",ORG,Sentence,"[2104, 2117): 'Dynamo Batumi'",,,"Sentence boundary between ""Dynamo"" and ""Batumi""",False,True,True,True
+train,43,"[2364, 2368): 'Petr'",PER,Sentence,"[2364, 2376): 'Petr Gabriel'",,,Sentence boundary between first and last name,False,True,True,True
+train,43,"[2682, 2690): 'Chisinau'",ORG,Sentence,"[2668, 2690): 'Constructorul Chisinau'",,,"Sentence boundary between ""Constructorul"" and ""Chisinau""",False,True,True,True
+train,43,"[2765, 2777): 'Anjalonkoski'",MISC,Tag,"[2765, 2777): 'Anjalonkoski'",LOC,,,False,False,True,True
+train,43,"[2765, 2777): 'Anjalonkoski'",LOC,Tag,"[2765, 2777): 'Anjalonkoski'",LOC,,https://en.wikipedia.org/wiki/Anjalankoski,False,True,False,True
+train,43,"[107, 110): 'Cup'",MISC,Sentence,"[84, 110): 'European Cup Winners ' Cup'",,,"Sentence boundary between ""Winners"" and ""Cup""",False,True,True,True
+train,47,"[229, 235): 'Sun-ho'",MISC,Both,"[223, 235): 'Hwang Sun-ho'",PER,,,False,False,True,True
+train,47,"[85, 94): 'Malaysian'",MISC,Sentence,"[85, 99): 'Malaysian Open'",MISC,,,False,False,True,True
+train,47,"[229, 235): 'Sun-ho'",MISC,Wrong,,,,,False,True,False,True
+train,48,"[157, 160): 'U.S'",LOC,Sentence,"[157, 184): 'U.S. National Tennis Centre'",,,"Sentence boundary between ""U.S."" and ""National""",False,False,True,True
+train,50,"[1249, 1257): 'COLORADO'",LOC,Tag,"[1249, 1257): 'COLORADO'",ORG,,Baseball team,False,False,False,True
+train,50,"[1272, 1279): 'ATLANTA'",LOC,Tag,"[1272, 1279): 'ATLANTA'",ORG,,Baseball team,False,False,False,True
+train,50,"[1294, 1301): 'HOUSTON'",LOC,Tag,"[1294, 1301): 'HOUSTON'",ORG,,Baseball team,False,False,False,True
+train,50,"[1318, 1329): 'LOS ANGELES'",LOC,Tag,"[1318, 1329): 'LOS ANGELES'",ORG,,Baseball team,False,False,True,True
+train,50,"[1342, 1355): 'SAN FRANCISCO'",LOC,Tag,"[1342, 1355): 'SAN FRANCISCO'",ORG,,Baseball team,False,False,False,True
+train,50,"[672, 678): 'BOSTON'",LOC,Tag,"[672, 678): 'BOSTON'",ORG,,Baseball team,False,False,False,True
+train,50,"[690, 699): 'BALTIMORE'",LOC,Tag,"[690, 699): 'BALTIMORE'",ORG,,Baseball team,False,False,False,True
+train,50,"[714, 722): 'NEW YORK'",LOC,Tag,"[714, 722): 'NEW YORK'",ORG,,Baseball team,False,False,False,True
+train,50,"[734, 741): 'CHICAGO'",LOC,Tag,"[734, 741): 'CHICAGO'",ORG,,Baseball team,False,False,False,True
+train,50,"[753, 764): 'KANSAS CITY'",LOC,Tag,"[753, 764): 'KANSAS CITY'",ORG,,Baseball team,False,False,True,True
+train,50,"[774, 783): 'MINNESOTA'",LOC,Tag,"[774, 783): 'MINNESOTA'",ORG,,Baseball team,False,False,False,True
+train,50,"[234, 250): 'EASTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+train,50,"[375, 391): 'CENTRAL DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+train,50,"[525, 541): 'WESTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+train,50,"[800, 816): 'EASTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+train,50,"[947, 963): 'CENTRAL DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+train,50,"[1086, 1102): 'WESTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+train,51,"[84, 96): 'Major League'",MISC,Sentence,"[84, 105): 'Major League Baseball'",,,"Sentence boundary between ""League"" and ""Baseball""",False,True,False,True
+train,52,"[2054, 2063): 'Baltimore'",LOC,Tag,"[2054, 2063): 'Baltimore'",ORG,,BaltimoreÊhas won seven of nine and 16 of its last 22,False,True,True,True
+train,52,"[2016, 2019): 'RBI'",MISC,Wrong,,,,Run batted in,False,False,False,True
+train,52,"[2264, 2267): 'RBI'",MISC,Wrong,,,,Runs batted in,False,False,False,True
+train,52,"[3472, 3475): 'RBI'",MISC,Wrong,,,,Runs batted in,False,False,False,True
+train,52,"[4026, 4029): 'ERA'",MISC,Wrong,,,,Earned run average,False,False,False,True
+train,52,"[4230, 4233): 'ERA'",MISC,Wrong,,,,Earned run average,False,False,False,True
+train,52,"[4411, 4414): 'RBI'",MISC,Wrong,,,,Runs batted in,False,False,False,True
+train,52,"[4448, 4451): 'RBI'",MISC,Wrong,,,,Runs batted in,False,False,False,True
+train,54,,,Missing,"[176, 181): 'Numan'",PER,,,False,True,True,True
+train,56,"[171, 182): 'Switzerland'",LOC,Tag,"[171, 182): 'Switzerland'",ORG,,Soccer team,False,False,False,True
+train,56,"[219, 229): 'Azerbaijan'",LOC,Tag,"[219, 229): 'Azerbaijan'",ORG,,Soccer team,False,False,False,True
+train,56,"[442, 453): 'Switzerland'",LOC,Tag,"[442, 453): 'Switzerland'",ORG,,Soccer team,False,False,False,True
+train,56,"[829, 838): 'Stuttgart'",LOC,Tag,"[829, 838): 'Stuttgart'",ORG,,Soccer team,False,False,False,True
+train,56,"[859, 867): 'Lausanne'",LOC,Tag,"[859, 867): 'Lausanne'",ORG,,Soccer team,False,False,True,True
+train,58,"[1096, 1102): 'Spence'",PER,Sentence,"[1090, 1102): 'Jamie Spence'",PER,,Sentence boundary between first and last name,False,False,True,True
+train,58,"[1090, 1095): 'Jamie'",PER,Sentence,"[1090, 1102): 'Jamie Spence'",,,Sentence boundary between first and last name,False,True,False,True
+train,58,"[271, 274): 'Ian'",PER,Sentence,"[271, 282): 'Ian Woosnam'",PER,,Sentence boundary between first and last name,False,False,True,True
+train,58,"[332, 338): 'Lanner'",PER,Sentence,"[327, 338): 'Mats Lanner'",PER,,Sentence boundary between first and last name,False,False,True,True
+train,58,"[327, 331): 'Mats'",PER,Sentence,"[327, 338): 'Mats Lanner'",,,Sentence boundary between first and last name,False,True,False,True
+train,58,"[653, 661): 'Chalmers'",PER,Sentence,"[648, 661): 'Greg Chalmers'",,,Sentence boundary between first and last name,False,True,False,True
+train,58,"[648, 652): 'Greg'",PER,Sentence,"[648, 661): 'Greg Chalmers'",PER,,Sentence boundary between first and last name,False,False,True,True
+train,58,"[751, 758): 'Derrick'",PER,Sentence,"[751, 765): 'Derrick Cooper'",,,Sentence boundary between first and last name,False,True,False,True
+train,58,"[759, 765): 'Cooper'",PER,Sentence,"[751, 765): 'Derrick Cooper'",PER,,Sentence boundary between first and last name,False,False,True,True
+train,58,"[824, 829): 'Welch'",PER,Sentence,"[816, 829): 'Michael Welch'",,,Sentence boundary between first and last name,False,True,False,True
+train,58,"[816, 823): 'Michael'",PER,Sentence,"[816, 829): 'Michael Welch'",PER,,Sentence boundary between first and last name,False,False,True,True
+train,70,,,Missing,"[306, 315): 'Soufriere'",LOC,,City in Saint Lucia,False,False,False,True
+train,70,"[424, 432): 'Plymouth'",ORG,Tag,"[424, 432): 'Plymouth'",LOC,,,False,False,True,True
+train,80,,,Token,"[44, 59): 'Interfax'",ORG,,"Missing annotation, and 'rebels-Interfax' treated as a single token",False,True,False,True
+train,80,,,Token,"[51, 59): 'Interfax'",ORG,,"Tokenizer treats ""rebels-Interfax"" as a single token",False,False,True,True
+train,98,,,Missing,"[81, 85): 'N.M.'",LOC,,,False,True,True,True
+train,115,,,Token,"[23, 27): 'News'",,,"FOCUS-News' treated as a single token; ""News"" is a reference to News Corp Ltd",False,True,False,True
+train,119,,,Missing,"[11, 16): 'Thais'",MISC,,,False,True,True,True
+train,119,,,Missing,"[826, 831): 'Vivit'",PER,,,False,True,True,True
+train,122,"[436, 444): 'Chua Jui'",PER,Span,"[436, 449): 'Chua Jui Meng'",,,,False,False,True,True
+train,136,"[1022, 1027): 'Wasim'",PER,Sentence,"[1022, 1033): 'Wasim Akram'",PER,,Sentence boundary between first and last name,False,False,True,True
+train,136,"[1028, 1033): 'Akram'",PER,Sentence,"[1022, 1033): 'Wasim Akram'",,,Sentence boundary between first and last name,False,True,False,True
+train,136,"[145, 152): 'England'",LOC,Tag,"[145, 152): 'England'",ORG,,the third and final test betweenï¿½Englandï¿½andï¿½Pakistan,False,False,False,True
+train,136,"[157, 165): 'Pakistan'",LOC,Tag,"[157, 165): 'Pakistan'",ORG,,the third and final test betweenï¿½Englandï¿½andï¿½Pakistan,False,False,False,True
+train,136,"[169, 172): 'The'",LOC,Sentence,"[169, 177): 'The Oval'",LOC,,"Sentence boundary between ""The"" and ""Oval""",False,False,True,True
+train,136,"[173, 177): 'Oval'",LOC,Sentence,"[169, 177): 'The Oval'",,,"Sentence boundary between ""The"" and ""Oval""",False,True,False,True
+train,136,"[189, 196): 'England'",LOC,Tag,"[189, 196): 'England'",ORG,,Cricket team,False,False,False,True
+train,136,"[20, 27): 'ENGLAND'",LOC,Tag,"[20, 27): 'ENGLAND'",ORG,,CRICKET-ï¿½ENGLANDï¿½Vï¿½PAKISTANï¿½FINAL TEST SCOREBOARD,False,False,False,True
+train,136,"[30, 38): 'PAKISTAN'",LOC,Tag,"[30, 38): 'PAKISTAN'",ORG,,CRICKET-ï¿½ENGLANDï¿½Vï¿½PAKISTANï¿½FINAL TEST SCOREBOARD,False,False,False,True
+train,136,"[801, 809): 'Pakistan'",LOC,Tag,"[801, 809): 'Pakistan'",ORG,,Cricket team,False,False,False,True
+train,140,"[560, 565): 'Czech'",LOC,Sentence,"[560, 574): 'Czech Republic'",LOC,,"Sentence boundary between ""Czech"" and ""Republic""",False,False,True,True
+train,140,"[566, 574): 'Republic'",LOC,Sentence,"[560, 574): 'Czech Republic'",,,"Sentence boundary between ""Czech"" and ""Republic""",False,True,False,True
+train,142,"[105, 109): 'Open'",MISC,Sentence,"[95, 109): 'Malaysian Open'",,,"Sentence boundary between ""Malaysian"" and ""Open""",False,True,False,True
+train,142,"[95, 104): 'Malaysian'",MISC,Sentence,"[95, 109): 'Malaysian Open'",MISC,,"Sentence boundary between ""Malaysian"" and ""Open""",False,False,True,True
+train,144,"[1255, 1262): 'FLORIDA'",LOC,Tag,"[1255, 1262): 'FLORIDA'",ORG,,Baseball team,False,False,False,True
+train,144,"[1289, 1296): 'ATLANTA'",LOC,Tag,"[1289, 1296): 'ATLANTA'",ORG,,Baseball team,False,False,False,True
+train,144,"[1309, 1316): 'HOUSTON'",LOC,Tag,"[1309, 1316): 'HOUSTON'",ORG,,Baseball team,False,False,False,True
+train,144,"[1331, 1339): 'COLORADO'",LOC,Tag,"[1331, 1339): 'COLORADO'",ORG,,Baseball team,False,False,True,True
+train,144,"[1352, 1363): 'LOS ANGELES'",LOC,Tag,"[1352, 1363): 'LOS ANGELES'",ORG,,Baseball team,False,False,True,True
+train,144,"[655, 661): 'BOSTON'",LOC,Tag,"[655, 661): 'BOSTON'",ORG,,Baseball team,False,False,False,True
+train,144,"[675, 684): 'CLEVELAND'",LOC,Tag,"[675, 684): 'CLEVELAND'",ORG,,Baseball team,False,False,False,True
+train,144,"[699, 708): 'BALTIMORE'",LOC,Tag,"[699, 708): 'BALTIMORE'",ORG,,Baseball team,False,False,False,True
+train,144,"[720, 728): 'NEW YORK'",LOC,Tag,"[720, 728): 'NEW YORK'",ORG,,Baseball team,False,False,False,True
+train,144,"[740, 747): 'CHICAGO'",LOC,Tag,"[740, 747): 'CHICAGO'",ORG,,Baseball team,False,False,False,True
+train,144,"[759, 770): 'KANSAS CITY'",LOC,Tag,"[759, 770): 'KANSAS CITY'",ORG,,Baseball team,False,False,True,True
+train,144,"[232, 248): 'EASTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+train,144,"[372, 388): 'CENTRAL DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+train,144,"[510, 526): 'WESTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+train,144,"[806, 822): 'EASTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+train,144,"[953, 969): 'CENTRAL DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+train,144,"[1096, 1112): 'WESTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+train,145,"[83, 95): 'Major League'",MISC,Sentence,"[83, 104): 'Major League Baseball'",MISC,,"Sentence boundary between ""League"" and ""Baseball""",False,False,True,True
+train,158,"[684, 690): 'Jonzon'",PER,Sentence,"[676, 690): 'Michael Jonzon'",PER,,Sentence boundary between first and last name,False,False,True,True
+train,158,"[676, 683): 'Michael'",PER,Sentence,"[676, 690): 'Michael Jonzon'",,,Sentence boundary between first and last name,False,True,False,True
+train,158,"[837, 842): 'Riley'",PER,Sentence,"[831, 842): 'Wayne Riley'",PER,,Sentence boundary between first and last name,False,False,True,True
+train,158,"[831, 836): 'Wayne'",PER,Sentence,"[831, 842): 'Wayne Riley'",,,Sentence boundary between first and last name,False,True,False,True
+train,158,"[1002, 1007): 'Smyth'",PER,Sentence,"[998, 1007): 'Des Smyth'",PER,,Sentence boundary between first and last name,False,False,True,True
+train,158,"[998, 1001): 'Des'",PER,Sentence,"[998, 1007): 'Des Smyth'",,,Sentence boundary between first and last name,False,True,False,True
+train,163,"[220, 232): 'x-AEK Athens'",ORG,Token,"[222, 232): 'AEK Athens'",ORG,,"Tokenizer treated ""x-AEK"" as a single token",False,False,False,True
+train,163,"[271, 283): 'x-Olympiakos'",ORG,Token,"[273, 283): 'Olympiakos'",ORG,,"Tokenizer treated ""x-Olympiakos"" as a single token",False,False,False,True
+train,163,"[308, 313): 'x-PAO'",ORG,Token,"[310, 313): 'PAO'",ORG,,"Tokenizer treated ""x-PAO"" as a single token",False,False,False,True
+train,169,"[50, 61): 'trip-Canada'",LOC,Token,"[55, 61): 'Canada'",LOC,,"Tokenizer treated ""trip-Canada"" as a single token",False,False,True,True
+train,184,,,Missing,"[419, 427): 'Ministry'",ORG,,,False,False,True,True
+train,208,"[143, 161): 'The Walt Disney Co'",ORG,Sentence,"[143, 162): 'The Walt Disney Co.'",ORG,,"Incorrect sentence boundary after ""Co."" makes it look like the period is not part of the abbreviation when in fact it is",False,False,True,True
+train,208,"[143, 161): 'The Walt Disney Co'",,Span,"[143, 162): 'The Walt Disney Co.'",,,,False,True,False,True
+train,208,"[2962, 2980): 'Kalf, Voorhis & Co'",,Span,"[2962, 2981): 'Kalf, Voorhis & Co.'",,,"Comma after period after ""Co""",False,True,False,True
+train,208,"[2962, 2980): 'Kalf, Voorhis & Co'",ORG,Sentence,"[2962, 2981): 'Kalf, Voorhis & Co.'",ORG,,"Incorrect sentence boundary after ""Co."" makes it look like the period is not part of the abbreviation when in fact it is",False,False,True,True
+train,249,"[247, 252): 'Waqar'",PER,Sentence,"[247, 259): 'Waqar Younis'",,,Sentence boundary between first and last name,False,True,False,True
+train,249,"[253, 259): 'Younis'",PER,Sentence,"[247, 259): 'Waqar Younis'",PER,,Sentence boundary between first and last name,False,False,True,True
+train,262,"[1245, 1252): 'ATLANTA'",LOC,Tag,"[1245, 1252): 'ATLANTA'",ORG,,Baseball team,False,False,False,True
+train,262,"[1265, 1272): 'HOUSTON'",LOC,Tag,"[1265, 1272): 'HOUSTON'",ORG,,Baseball team,False,False,False,True
+train,262,"[1285, 1296): 'LOS ANGELES'",LOC,Tag,"[1285, 1296): 'LOS ANGELES'",ORG,,Baseball team,False,False,True,True
+train,262,"[1309, 1322): 'SAN FRANCISCO'",LOC,Tag,"[1309, 1322): 'SAN FRANCISCO'",ORG,,Baseball team,False,False,False,True
+train,262,"[1337, 1344): 'FLORIDA'",LOC,Tag,"[1337, 1344): 'FLORIDA'",ORG,,Baseball team,False,False,True,True
+train,262,"[1359, 1367): 'COLORADO'",LOC,Tag,"[1359, 1367): 'COLORADO'",ORG,,Baseball team,False,False,False,True
+train,262,"[1384, 1393): 'SAN DIEGO'",LOC,Tag,"[1384, 1393): 'SAN DIEGO'",ORG,,Baseball team,False,False,False,True
+train,262,"[656, 662): 'BOSTON'",LOC,Tag,"[656, 662): 'BOSTON'",ORG,,Baseball team,False,False,False,True
+train,262,"[676, 685): 'CLEVELAND'",LOC,Tag,"[676, 685): 'CLEVELAND'",ORG,,Baseball team,False,False,False,True
+train,262,"[700, 709): 'BALTIMORE'",LOC,Tag,"[700, 709): 'BALTIMORE'",ORG,,Baseball team,False,False,False,True
+train,262,"[721, 728): 'CHICAGO'",LOC,Tag,"[721, 728): 'CHICAGO'",ORG,,Baseball team,False,False,False,True
+train,262,"[740, 748): 'NEW YORK'",LOC,Tag,"[740, 748): 'NEW YORK'",ORG,,Baseball team,False,False,True,True
+train,262,"[760, 771): 'KANSAS CITY'",LOC,Tag,"[760, 771): 'KANSAS CITY'",ORG,,Baseball team,False,False,True,True
+train,262,"[228, 244): 'EASTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+train,262,"[369, 385): 'CENTRAL DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+train,262,"[507, 523): 'WESTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+train,262,"[807, 823): 'EASTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+train,262,"[950, 966): 'CENTRAL DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+train,262,"[1085, 1101): 'WESTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+train,263,"[81, 93): 'Major League'",MISC,Sentence,"[81, 102): 'Major League Baseball'",,,"Sentence boundary between ""League"" and ""Baseball""",False,True,False,True
+train,283,"[866, 874): 'Florence'",LOC,Both,"[866, 883): 'Florence Chitauro'",PER,,,False,True,True,True
+train,287,,,Missing,"[20, 30): 'Socialists'",ORG,,Albania's oppositionï¿½Socialist Party,False,False,False,True
+train,298,"[49, 60): '1997--Ruehe'",MISC,Token,"[55, 60): 'Ruehe'",PER,,"Tokenizer treated ""1997--Ruehe"" as a single token",False,False,True,True
+train,300,"[786, 792): 'Verona'",PER,Tag,"[786, 792): 'Verona'",LOC,,,False,False,True,True
+train,309,"[548, 554): 'Brooks'",PER,Sentence,"[543, 554): 'Mark Brooks'",PER,,Sentence boundary between first and last name,False,False,True,True
+train,309,"[543, 547): 'Mark'",PER,Sentence,"[543, 554): 'Mark Brooks'",,,Sentence boundary between first and last name,False,True,False,True
+train,309,"[661, 668): 'O'Meara'",PER,Sentence,"[656, 668): 'Mark O'Meara'",PER,,Sentence boundary between first and last name,False,False,True,True
+train,309,"[656, 660): 'Mark'",PER,Sentence,"[656, 668): 'Mark O'Meara'",,,Sentence boundary between first and last name,False,True,False,True
+train,309,"[787, 791): 'Fred'",PER,Sentence,"[787, 799): 'Fred Couples'",PER,,Sentence boundary between first and last name,False,False,True,True
+train,309,"[792, 799): 'Couples'",PER,Sentence,"[787, 799): 'Fred Couples'",,,Sentence boundary between first and last name,False,True,False,True
+train,310,"[227, 235): 'Republic'",LOC,Sentence,"[221, 235): 'Czech Republic'",LOC,,"Sentence boundary between ""Czech"" and ""Republic""",False,False,True,True
+train,310,"[221, 226): 'Czech'",LOC,Sentence,"[221, 235): 'Czech Republic'",,,"Sentence boundary between ""Czech"" and ""Republic""",False,True,False,True
+train,310,"[93, 96): 'Cup'",MISC,Sentence,"[86, 96): 'Hamlet Cup'",MISC,,"Sentence boundary between ""Hamlet"" and ""Cup""",False,False,True,True
+train,315,"[1179, 1195): 'Marcos LM600 162'",MISC,Sentence,"[1175, 1191): 'GT2 Marcos LM600'",,,"Sentence boundary between ""GT2"" and ""Marcos""; also ""162"" not part of name",False,True,False,True
+train,315,"[1175, 1178): 'GT2'",MISC,Sentence,"[1175, 1195): 'GT2 Marcos LM600 162'",MISC,,"Sentence boundary between ""GT2"" and ""Marcos""",False,False,False,True
+train,315,,,Missing,"[257, 266): 'J.J.Lehto'",PER,,,False,True,True,True
+train,315,"[424, 429): 'Ennea'",MISC,Sentence,"[424, 441): 'Ennea Ferrari F40'",MISC,,"Sentence boundary between ""Ennea"" and ""Ferrari""",False,False,False,True
+train,315,"[506, 513): 'Harrods'",MISC,Sentence,"[506, 528): 'Harrods McLaren FI GTR'",MISC,,"Sentence boundary between ""GTR"" and ""West""",False,False,True,True
+train,315,"[585, 597): 'West McLaren'",MISC,Sentence,"[585, 604): 'West McLaren F1 GTR'",MISC,,"Sentence boundary between ""McLaren"" and ""F1""",False,False,False,True
+train,315,"[803, 806): 'GTR'",,Sentence,"[787, 806): 'Gulf McLaren F! GTR'",,,"Sentence boundary before ""GTR""",False,True,False,True
+train,315,"[803, 806): 'GTR'",MISC,Sentence,"[787, 806): 'Gulf McLaren F! GTR'",MISC,,"Sentence boundary between ""F!"" (sic.) and ""GTR""",False,False,True,True
+train,315,"[864, 868): 'Paul'",PER,Sentence,"[864, 877): 'Paul Belmondo'",PER,,Sentence boundary between first and last name,False,False,True,True
+train,315,"[869, 877): 'Belmondo'",PER,Sentence,"[864, 877): 'Paul Belmondo'",,,,False,True,False,True
+train,317,"[407, 415): 'Williams'",PER,Tag,"[407, 415): 'Williams'",ORG,,"F1 team; tagged correctly at [272, 280): 'Williams'	",False,True,True,True
+train,318,,,Missing,"[1177, 1185): 'Footwork'",ORG,,https://en.wikipedia.org/wiki/Footwork_Arrows,False,False,False,True
+train,319,"[156, 167): '1,000 Lakes'",MISC,Sentence,"[156, 173): '1,000 Lakes Rally'",,,"Sentence boundary between ""Lakes"" and ""Rally""",False,True,False,True
+train,319,"[168, 173): 'Rally'",MISC,Sentence,"[156, 173): '1,000 Lakes Rally'",MISC,,"Sentence boundary between ""Lakes"" and ""Rally""",False,False,True,True
+train,328,"[145, 152): 'England'",LOC,Tag,"[145, 152): 'England'",ORG,,Cricket team,False,False,False,True
+train,328,"[157, 165): 'Pakistan'",LOC,Tag,"[157, 165): 'Pakistan'",ORG,,Cricket team,False,False,False,True
+train,328,"[173, 177): 'Oval'",LOC,Sentence,"[169, 177): 'The Oval'",LOC,,"Sentence boundary between ""The"" and ""Oval""",False,False,True,True
+train,328,"[20, 27): 'ENGLAND'",LOC,Tag,"[20, 27): 'ENGLAND'",ORG,,Cricket team,False,False,False,True
+train,328,"[252, 258): 'Younis'",PER,Sentence,"[246, 258): 'Waqar Younis'",PER,,Sentence boundary between first and last name,False,False,True,True
+train,328,"[246, 251): 'Waqar'",PER,Sentence,"[246, 258): 'Waqar Younis'",,,Sentence boundary between first and last names,False,True,False,True
+train,328,"[265, 273): 'Pakistan'",LOC,Tag,"[265, 273): 'Pakistan'",ORG,,Cricket team,False,False,False,True
+train,328,"[30, 38): 'PAKISTAN'",LOC,Tag,"[30, 38): 'PAKISTAN'",ORG,,Cricket team,False,False,False,True
+train,328,"[873, 880): 'England'",LOC,Tag,"[873, 880): 'England'",ORG,,Cricket team,False,False,False,True
+train,339,"[546, 553): 'Mariusz'",PER,Sentence,"[546, 560): 'Mariusz Srutwa'",PER,,Sentence boundary between first and last name,False,False,True,True
+train,339,"[554, 560): 'Srutwa'",PER,Sentence,"[546, 560): 'Mariusz Srutwa'",,,Sentence boundary between first and last names,False,True,False,True
+train,343,"[11, 31): 'AUSTRALIAN RULES-AFL'","[11, 21): 'AUSTRALIAN'",Token,MISC,,,"""RULES-AFL"" treated as a single token",False,True,False,True
+train,343,"[11, 31): 'AUSTRALIAN RULES-AFL'","[28, 31): 'AFL'",Token,ORG,,,"""RULES-AFL"" treated as a single token; AFL == Australian Football League",False,True,False,True
+train,343,"[11, 31): 'AUSTRALIAN RULES-AFL'",MISC,Token,"[11, 27): 'AUSTRALIAN RULES'",MISC,,"Tokenizer treated ""RULES-AFL"" as a single token",False,False,True,True
+train,343,"[11, 31): 'AUSTRALIAN RULES-AFL'",MISC,Token,"[28, 31): 'AFL'",MISC,,"Tokenizer treated ""RULES-AFL"" as a single token",False,False,True,True
+train,345,"[536, 541): 'Chong'",PER,Sentence,"[536, 550): 'Chong Tan Fook'",PER,,"Sentence boundary between ""Chong"" and ""Tan""",False,False,True,True
+train,345,"[542, 550): 'Tan Fook'",PER,Sentence,"[536, 550): 'Chong Tan Fook'",,,Sentence boundary between first and middle names,False,True,False,True
+train,346,"[207, 212): 'Lotte'",PER,Tag,"[207, 212): 'Lotte'",ORG,,Baseball team,False,False,True,True
+train,346,"[207, 212): 'Lotte'",,Tag,"[207, 212): 'Lotte'",ORG,,Baseball team,False,True,False,True
+train,346,"[215, 220): 'Lotte'",PER,Tag,"[215, 220): 'Lotte'",ORG,,Baseball team,False,False,True,True
+train,346,"[215, 220): 'Lotte'",,Tag,"[215, 220): 'Lotte'",ORG,,Baseball team,False,True,False,True
+train,346,"[243, 248): 'Lotte'",PER,Tag,"[243, 248): 'Lotte'",ORG,,Baseball team,False,False,True,True
+train,346,"[243, 248): 'Lotte'",,Tag,"[243, 248): 'Lotte'",ORG,,Baseball team,False,True,False,True
+train,347,"[81, 93): 'Major League'",MISC,Sentence,"[81, 102): 'Major League Baseball'",,,"Sentence boundary between ""League"" and ""Baseball""",False,True,False,True
+train,349,"[591, 611): 'Mariner Darren Bragg'",,Both,"[591, 598): 'Mariner'",MISC,,,False,False,False,True
+train,349,"[1001, 1010): 'Cleveland'",ORG,Tag,"[1001, 1010): 'Cleveland'",LOC,,"In Cleveland, Kevin Seitzer's two-out singleï¿½",False,True,True,True
+train,349,"[591, 611): 'Mariner Darren Bragg'",,Span,"[599, 611): 'Darren Bragg'",,,,False,True,False,True
+train,351,"[83, 95): 'Major League'",MISC,Sentence,"[83, 104): 'Major League Baseball'",,,"Sentence boundary between ""League"" and ""Baseball""",False,True,False,True
+train,355,,,Missing,"[175, 185): 'Supercoppa'",MISC,,,False,False,True,True
+train,359,"[386, 389): 'St.'",ORG,Span,"[386, 396): 'St. Gallen'",,,,False,True,True,True
+train,366,"[667, 675): 'Waalwijk'",ORG,Sentence,"[663, 675): 'RKC Waalwijk'",ORG,,"Sentence boundary between ""RKC"" and ""Waalwijk""",False,False,True,True
+train,366,"[663, 666): 'RKC'",ORG,Sentence,"[663, 675): 'RKC Waalwijk'",,,"Sentence boundary between ""RKC"" and ""Waalwijk""",False,True,False,True
+train,369,"[1086, 1095): 'Australia'",LOC,Tag,"[1086, 1095): 'Australia'",ORG,,Cricket team,False,False,False,True
+train,369,"[567, 574): 'England'",LOC,Tag,"[567, 574): 'England'",ORG,,Cricket team,False,False,False,True
+train,369,"[905, 913): 'Pakistan'",LOC,Tag,"[905, 913): 'Pakistan'",ORG,,Cricket team,False,False,False,True
+train,402,"[127, 138): 'Lakes Rally'",MISC,Sentence,"[121, 138): '1,000 Lakes Rally'",MISC,,"Sentence boundary between ""1,000"" and ""Lakes""",False,False,True,True
+train,402,"[121, 126): '1,000'",MISC,Sentence,"[121, 138): '1,000 Lakes Rally'",,,"Sentence boundary between ""1,000"" and ""Lakes""",False,True,False,True
+train,412,"[250, 256): 'Younis'",PER,Sentence,"[244, 256): 'Waqar Younis'",PER,,Sentence boundary between first and last name,False,False,True,True
+train,415,"[1153, 1159): 'Morton'",ORG,Sentence,"[1144, 1159): 'Greenock Morton'",ORG,,"Sentence boundary between ""Greenock"" and ""Morton""",False,False,True,True
+train,415,"[1144, 1152): 'Greenock'",ORG,Sentence,"[1144, 1159): 'Greenock Morton'",,,"Sentence boundary between ""Greenock"" and ""Morton""",False,True,False,True
+train,415,"[1299, 1304): 'South'",ORG,Sentence,"[1286, 1304): 'Queen of the South'",ORG,,"Sentence boundary between ""the"" and ""South""",False,False,True,True
+train,415,"[1286, 1298): 'Queen of the'",ORG,Sentence,"[1286, 1304): 'Queen of the South'",,,"Sentence boundary between ""the"" and ""South""",False,True,False,True
+train,422,"[236, 246): 'Videoton(*'",ORG,Token,"[236, 244): 'Videoton'",,,"""Videoton(*"" treated as a single token",False,False,False,True
+train,422,"[736, 743): 'Stadler'",ORG,Span,"[736, 746): 'Stadler FC'",,,,False,True,True,True
+train,436,"[3087, 3095): 'Perfetti'",PER,Span,"[3081, 3095): 'Flora Perfetti'",PER,,,False,False,True,True
+train,436,"[3081, 3086): 'Flora'",LOC,Wrong,,,,,False,False,True,True
+train,437,"[837, 845): 'Castilla'",ORG,Tag,"[837, 845): 'Castilla'",PER,,,False,False,False,True
+train,437,"[727, 730): 'RBI'",MISC,Wrong,,,,Runs batted in,False,False,False,True
+train,437,"[2460, 2463): 'RBI'",MISC,Wrong,,,,Runs batted in,False,False,False,True
+train,438,"[1230, 1243): 'SAN FRANCISCO'",LOC,Tag,"[1230, 1243): 'SAN FRANCISCO'",ORG,,Baseball team,False,False,False,True
+train,438,"[1256, 1263): 'HOUSTON'",LOC,Tag,"[1256, 1263): 'HOUSTON'",ORG,,Baseball team,False,True,True,True
+train,438,"[1278, 1286): 'COLORADO'",LOC,Tag,"[1278, 1286): 'COLORADO'",ORG,,Baseball team,False,False,False,True
+train,438,"[655, 662): 'DETROIT'",LOC,Tag,"[655, 662): 'DETROIT'",ORG,,Baseball team,False,False,False,True
+train,438,"[674, 683): 'BALTIMORE'",LOC,Tag,"[674, 683): 'BALTIMORE'",ORG,,Baseball team,False,False,False,True
+train,438,"[697, 704): 'TORONTO'",LOC,Tag,"[697, 704): 'TORONTO'",ORG,,Baseball team,False,False,False,True
+train,438,"[718, 725): 'CHICAGO'",LOC,Tag,"[718, 725): 'CHICAGO'",ORG,,Baseball team,False,False,False,True
+train,438,"[736, 746): 'CALIFORNIA'",LOC,Tag,"[736, 746): 'CALIFORNIA'",ORG,,Baseball team,False,False,False,True
+train,438,"[759, 766): 'SEATTLE'",LOC,Tag,"[759, 766): 'SEATTLE'",ORG,,Baseball team,False,False,False,True
+train,438,"[228, 244): 'EASTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+train,438,"[368, 384): 'CENTRAL DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+train,438,"[506, 522): 'WESTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+train,438,"[783, 799): 'EASTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+train,438,"[926, 942): 'CENTRAL DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+train,438,"[1067, 1083): 'WESTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+train,444,"[122, 128): 'Series'",MISC,Sentence,"[109, 128): 'Singer World Series'",MISC,,"Sentence boundary between ""World"" and ""Series""",False,False,True,True
+train,444,"[109, 121): 'Singer World'",MISC,Sentence,"[109, 128): 'Singer World Series'",,,"Sentence boundary between ""World"" and ""Series""",False,True,False,True
+train,444,"[1359, 1368): 'Australia'",LOC,Tag,"[1359, 1368): 'Australia'",ORG,,Cricket team,False,False,False,True
+train,444,"[170, 179): 'Australia'",LOC,Tag,"[170, 179): 'Australia'",ORG,,Cricket team,False,False,False,True
+train,444,"[184, 192): 'Zimbabwe'",LOC,Tag,"[184, 192): 'Zimbabwe'",ORG,,Cricket team,False,False,False,True
+train,444,"[204, 213): 'Australia'",LOC,Tag,"[204, 213): 'Australia'",ORG,,Cricket team,False,False,False,True
+train,444,"[761, 769): 'Zimbabwe'",LOC,Tag,"[761, 769): 'Zimbabwe'",ORG,,Cricket team,False,False,False,True
+train,458,"[1294, 1300): 'Nicola'",MISC,Both,"[1294, 1310): 'Nicola Fleuchaus'",PER,,,False,True,False,True
+train,458,"[1301, 1310): 'Fleuchaus'",PER,Span,"[1294, 1310): 'Nicola Fleuchaus'",,,,False,True,False,True
+train,458,"[1294, 1300): 'Nicola'",MISC,Wrong,,,,,False,False,True,True
+train,458,"[363, 366): 'Col'",LOC,Wrong,,,,"Abbreviation for ""Colonel"". Titles not considered entities; also tagged as LOC, which is doubly wrong",False,False,False,True
+train,487,,,Missing,"[911, 916): 'NYMEX'",ORG,,,False,False,True,True
+train,492,,,Missing,"[224, 257): 'OCASEK GOVERNMENT OFFICE BUILDING'",LOC,,https://das.ohio.gov/Divisions/General-Services/Properties-and-Facilities/Ocasek,False,False,False,True
+train,488,"[822, 826): 'Sask'",LOC,Sentence,"[822, 827): 'Sask.'",LOC,,Incorrect sentence boundary after period and before comma,False,False,True,True
+train,488,"[822, 826): 'Sask'",LOC,Span,"[822, 827): 'Sask.'",,,Period immediately before comma,False,True,False,True
+train,488,"[889, 893): 'Alta'",,Span,"[889, 894): 'Alta.'",,,,False,True,False,True
+train,492,,,Missing,"[283, 288): 'FITCH'",ORG,,Credit rating agency,False,False,False,True
+train,492,,,Missing,"[453, 458): 'FITCH'",ORG,,Credit rating agency,False,False,False,True
+train,523,"[603, 609): 'Rovers'",ORG,Sentence,"[595, 609): 'Bristol Rovers'",,,"Sentence boundary between ""Bristol"" and ""Rovers""",False,False,True,True
+train,523,"[595, 602): 'Bristol'",ORG,Sentence,"[595, 609): 'Bristol Rovers'",ORG,,"Sentence boundary between ""Bristol"" and ""Rovers""",False,True,True,True
+train,524,"[1095, 1103): 'Pakistan'",LOC,Tag,"[1095, 1103): 'Pakistan'",ORG,,Cricket team,False,False,False,True
+train,524,"[163, 170): 'England'",LOC,Tag,"[163, 170): 'England'",ORG,,Cricket team,False,False,False,True
+train,524,"[20, 27): 'ENGLAND'",LOC,Tag,"[20, 27): 'ENGLAND'",ORG,,Cricket team,False,False,False,True
+train,524,"[32, 40): 'PAKISTAN'",LOC,Tag,"[32, 40): 'PAKISTAN'",ORG,,Cricket team,False,False,False,True
+train,524,"[74, 81): 'England'",LOC,Tag,"[74, 81): 'England'",ORG,,Cricket team,False,False,False,True
+train,524,"[86, 94): 'Pakistan'",LOC,Tag,"[86, 94): 'Pakistan'",ORG,,Cricket team,False,False,False,True
+train,527,"[108, 117): 'Kong Open'",MISC,Sentence,"[103, 117): 'Hong Kong Open'",MISC,,"Sentence boundary between ""Hong"" and ""Kong""",False,False,True,True
+train,528,,,Missing,"[1768, 1783): 'fellow-American'",MISC,,,False,True,True,True
+train,528,"[591, 595): 'U.S.'",LOC,Both,"[591, 601): 'U.S. Opens'",MISC,,Multiple instances of the U.S. Open tennis tournament,False,True,False,True
+train,529,"[2369, 2374): 'Czech'",LOC,Sentence,"[2369, 2383): 'Czech Republic'",LOC,,"Sentence boundary between ""Czech"" and ""Republic""",False,True,True,True
+train,529,"[2431, 2439): 'Kleinova'",PER,Sentence,"[2424, 2439): 'Sandra Kleinova'",PER,,Sentence boundary between first and last name,False,False,True,True
+train,529,"[2424, 2430): 'Sandra'",PER,Sentence,"[2424, 2439): 'Sandra Kleinova'",,,Sentence boundary between first and last name,False,True,False,True
+train,530,"[1255, 1268): 'SAN FRANCISCO'",LOC,Tag,"[1255, 1268): 'SAN FRANCISCO'",ORG,,Baseball team,False,False,False,True
+train,530,"[1284, 1292): 'MONTREAL'",LOC,Tag,"[1284, 1292): 'MONTREAL'",ORG,,Baseball team,False,False,False,True
+train,530,"[1304, 1314): 'PITTSBURGH'",LOC,Tag,"[1304, 1314): 'PITTSBURGH'",ORG,,Baseball team,False,False,False,True
+train,530,"[1328, 1336): 'NEW YORK'",LOC,Tag,"[1328, 1336): 'NEW YORK'",ORG,,Baseball team,False,True,True,True
+train,530,"[1348, 1355): 'HOUSTON'",LOC,Tag,"[1348, 1355): 'HOUSTON'",ORG,,Baseball team,False,True,True,True
+train,530,"[1367, 1375): 'ST LOUIS'",LOC,Tag,"[1367, 1375): 'ST LOUIS'",ORG,,Baseball team,False,False,False,True
+train,530,"[1390, 1398): 'COLORADO'",LOC,Tag,"[1390, 1398): 'COLORADO'",ORG,,Baseball team,False,False,False,True
+train,530,"[664, 671): 'DETROIT'",LOC,Tag,"[664, 671): 'DETROIT'",ORG,,Baseball team,False,False,False,True
+train,530,"[683, 692): 'BALTIMORE'",LOC,Tag,"[683, 692): 'BALTIMORE'",ORG,,Baseball team,False,False,False,True
+train,530,"[706, 713): 'TORONTO'",LOC,Tag,"[706, 713): 'TORONTO'",ORG,,Baseball team,False,False,False,True
+train,530,"[727, 734): 'CHICAGO'",LOC,Tag,"[727, 734): 'CHICAGO'",ORG,,Baseball team,False,False,False,True
+train,530,"[744, 755): 'KANSAS CITY'",LOC,Tag,"[744, 755): 'KANSAS CITY'",ORG,,Baseball team,False,True,True,True
+train,530,"[766, 776): 'CALIFORNIA'",LOC,Tag,"[766, 776): 'CALIFORNIA'",ORG,,Baseball team,False,True,True,True
+train,530,"[789, 796): 'SEATTLE'",LOC,Tag,"[789, 796): 'SEATTLE'",ORG,,Baseball team,False,False,False,True
+train,530,"[228, 244): 'EASTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+train,530,"[368, 384): 'CENTRAL DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+train,530,"[510, 526): 'WESTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+train,530,"[813, 829): 'EASTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+train,530,"[960, 976): 'CENTRAL DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+train,530,"[1091, 1107): 'WESTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+train,534,"[1234, 1244): 'Washington'",LOC,Tag,"[1234, 1244): 'Washington'",PER,,Reference to a tennis player whose last name is Washington,False,True,True,True
+train,545,"[476, 479): 'Aki'",PER,Tag,"[476, 479): 'Aki'",ORG,,"Cycling team; correctly tagged ORG at [805, 808): 'Aki'",False,False,True,True
+train,551,"[517, 522): 'Villa'",PER,Tag,"[517, 522): 'Villa'",ORG,,,False,True,True,True
+train,566,,,Missing,"[47, 59): 'Commandments'",MISC,,"[239, 255): 'Ten Commandments' annotated as MISC in first sentence of article",False,False,True,True
+train,566,,,Missing,"[881, 887): 'Church'",ORG,,Catholic Church,False,False,False,True
+train,573,"[701, 712): 'Juan Carlos'",PER,Span,"[701, 720): 'Juan Carlos Ongania'",,,,False,False,True,True
+train,579,,,Missing,"[734, 737): 'U.N'",ORG,,,False,False,True,True
+train,579,"[15, 19): 'U.N.'",ORG,Span,"[734, 737): 'U.N'",,,"Instances of ""U.N."" elsewhere in the same document include final period",False,True,False,True
+train,582,"[1158, 1164): 'Spring'",LOC,Wrong,,,,"Spring wheat, a type of wheat",False,False,False,True
+train,583,"[35, 38): 'Ala'",LOC,Span,"[35, 39): 'Ala.'",,,Comma immediately after period indicates period part of the abbreviation,False,True,False,True
+train,583,"[35, 38): 'Ala'",LOC,Sentence,"[35, 39): 'Ala.'",LOC,,Sentence boundary between period and comma,False,False,True,True
+train,590,"[78, 99): 'Robert W. Baird & Co.'",ORG,Sentence,"[78, 106): 'Robert W. Baird & Co. , Inc.'",,,"Sentence boundary between ""Co."" and "",""",False,True,False,True
+train,590,"[100, 106): ', Inc.'",ORG,Sentence,"[78, 106): 'Robert W. Baird & Co. , Inc.'",ORG,,Sentence boundary between period and comma,False,False,True,True
+train,593,"[45, 57): 'France-Juppe'",MISC,Token,"[45, 51): 'France'",LOC,,"Tokenizer treated ""France-Juppe"" as a single token",False,False,True,True
+train,593,"[45, 57): 'France-Juppe'",MISC,Token,"[52, 57): 'Juppe'",PER,,"Tokenizer treated ""France-Juppe"" as a single token",False,False,True,True
+train,594,"[1236, 1246): 'Eurotunnel'",LOC,Tag,"[1236, 1246): 'Eurotunnel'",ORG,,"Reference to company that operates the tunnel: ""active Eurotunnel was unchanged on nearly a million shares traded.""",False,True,True,True
+train,595,,,Missing,"[1148, 1165): 'Cultural Ministry'",ORG,,,False,True,False,True
+train,601,"[821, 830): 'Bhavnagar'",ORG,Tag,"[821, 830): 'Bhavnagar'",LOC,,"""3,800-3,825 rupees FOR Bhavnagar"", meaning ""3800 rupees per ton delivered to the city of Bhavnagar""",False,True,False,True
+train,608,,,Missing,"[517, 524): 'Hanover'",LOC,,,False,True,True,True
+train,609,"[135, 143): 'Sudanese'",MISC,Span,"[135, 151): 'Sudanese Airways'",,,,False,False,True,True
+train,611,"[37, 42): 'Power'",ORG,Span,"[37, 52): 'Power Financial'",,,Power Financial Corp,False,True,True,True
+train,623,"[238, 250): 'North Island'",PER,Tag,"[238, 250): 'North Island'",MISC,,,False,False,True,True
+train,626,"[42, 59): 'disarmament-China'",MISC,Token,"[42, 59): 'disarmament-China'",,,disarmament-China' treated as a single token,False,True,False,True
+train,637,"[1048, 1055): 'Harwood'",PER,Sentence,"[1043, 1055): 'Mike Harwood'",PER,,Sentence boundary between first and last name,False,False,True,True
+train,637,"[1043, 1047): 'Mike'",PER,Sentence,"[1043, 1055): 'Mike Harwood'",,,Sentence boundary between first and last name,False,True,False,True
+train,637,"[1106, 1116): 'Teravainen'",PER,Sentence,"[1100, 1116): 'Peter Teravainen'",PER,,Sentence boundary between first and last name,False,False,True,True
+train,637,"[1100, 1105): 'Peter'",PER,Sentence,"[1100, 1116): 'Peter Teravainen'",,,Sentence boundary between first and last name,False,True,False,True
+train,637,"[785, 793): 'Chistian'",PER,Sentence,"[785, 800): 'Chistian Cevaer'",,,Sentence boundary between first and last name,False,True,False,True
+train,637,"[794, 800): 'Cevaer'",PER,Sentence,"[785, 800): 'Chistian Cevaer'",PER,,Sentence boundary between first and last name,False,False,True,True
+train,640,"[573, 576): 'Aki'",PER,Tag,"[573, 576): 'Aki'",ORG,,Cycling team,False,False,True,True
+train,640,"[869, 872): 'Aki'",PER,Tag,"[869, 872): 'Aki'",ORG,,Cycling team,False,False,False,True
+train,657,"[103, 112): 'Kong Open'",MISC,Sentence,"[98, 112): 'Hong Kong Open'",MISC,,"Sentence boundary between ""Hong"" and ""Kong""",False,False,True,True
+train,659,"[267, 286): 'Hapoel Ironi Rishon'",ORG,Span,"[267, 293): 'Hapoel Ironi Rishon Lezion'",,,,False,False,True,True
+train,659,"[416, 424): 'Tel Aviv'",ORG,Span,"[408, 424): 'Maccabi Tel Aviv'",,,,False,True,True,True
+train,663,"[1262, 1270): 'COLORADO'",LOC,Tag,"[1262, 1270): 'COLORADO'",ORG,,Baseball team,False,False,False,True
+train,663,"[1286, 1294): 'MONTREAL'",LOC,Tag,"[1286, 1294): 'MONTREAL'",ORG,,Baseball team,False,False,False,True
+train,663,"[1306, 1316): 'PITTSBURGH'",LOC,Tag,"[1306, 1316): 'PITTSBURGH'",ORG,,Baseball team,False,False,False,True
+train,663,"[1330, 1338): 'NEW YORK'",LOC,Tag,"[1330, 1338): 'NEW YORK'",ORG,,Baseball team,False,False,False,True
+train,663,"[1350, 1357): 'HOUSTON'",LOC,Tag,"[1350, 1357): 'HOUSTON'",ORG,,Baseball team,False,False,True,True
+train,663,"[1369, 1377): 'ST LOUIS'",LOC,Tag,"[1369, 1377): 'ST LOUIS'",ORG,,Baseball team,False,False,False,True
+train,663,"[1394, 1407): 'SAN FRANCISCO'",LOC,Tag,"[1394, 1407): 'SAN FRANCISCO'",ORG,,Baseball team,False,False,False,True
+train,663,"[669, 676): 'DETROIT'",LOC,Tag,"[669, 676): 'DETROIT'",ORG,,Baseball team,False,False,False,True
+train,663,"[690, 697): 'CHICAGO'",LOC,Tag,"[690, 697): 'CHICAGO'",ORG,,Baseball team,False,False,False,True
+train,663,"[709, 718): 'BALTIMORE'",LOC,Tag,"[709, 718): 'BALTIMORE'",ORG,,Baseball team,False,False,False,True
+train,663,"[732, 739): 'TORONTO'",LOC,Tag,"[732, 739): 'TORONTO'",ORG,,Baseball team,False,False,False,True
+train,663,"[749, 760): 'KANSAS CITY'",LOC,Tag,"[749, 760): 'KANSAS CITY'",ORG,,Baseball team,False,False,False,True
+train,663,"[771, 781): 'CALIFORNIA'",LOC,Tag,"[771, 781): 'CALIFORNIA'",ORG,,Baseball team,False,False,False,True
+train,663,"[794, 801): 'SEATTLE'",LOC,Tag,"[794, 801): 'SEATTLE'",ORG,,Baseball team,False,False,False,True
+train,663,"[230, 246): 'EASTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+train,663,"[370, 386): 'CENTRAL DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+train,663,"[513, 529): 'WESTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+train,663,"[818, 834): 'EASTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+train,663,"[965, 981): 'CENTRAL DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+train,663,"[1098, 1114): 'WESTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+train,664,"[82, 94): 'Major League'",MISC,Sentence,"[82, 103): 'Major League Baseball'",MISC,,"Sentence boundary between ""League"" and ""Baseball""",False,True,True,True
+train,668,"[1238, 1246): 'Calderon'",LOC,Span,"[1230, 1246): 'Vicente Calderon'",LOC,,https://en.wikipedia.org/wiki/Vicente_Calder%C3%B3n_Stadium,False,False,False,True
+train,668,"[1230, 1237): 'Vicente'",PER,Wrong,,,,,False,False,False,True
+train,676,"[199, 208): 'Becanovic'",PER,Sentence,"[191, 208): 'Miladin Becanovic'",PER,,Sentence boundary between first and last name,False,False,True,True
+train,676,"[191, 198): 'Miladin'",PER,Sentence,"[191, 208): 'Miladin Becanovic'",,,Sentence boundary between first and last name,False,True,False,True
+train,676,"[377, 382): 'Scifo'",PER,Sentence,"[372, 382): 'Enzo Scifo'",PER,,Sentence boundary between first and last name,False,False,True,True
+train,676,"[372, 376): 'Enzo'",PER,Sentence,"[372, 382): 'Enzo Scifo'",,,Sentence boundary between first and last name,False,True,False,True
+train,678,"[323, 333): 'de Nooijer'",PER,Sentence,"[316, 333): 'Gerard de Nooijer'",PER,,Sentence boundary between first and last name,False,False,True,True
+train,678,"[316, 322): 'Gerard'",PER,Sentence,"[316, 333): 'Gerard de Nooijer'",,,Sentence boundary between first and last name,False,True,False,True
+train,678,"[573, 583): 'Doetinchem'",ORG,Sentence,"[562, 583): 'Graafschap Doetinchem'",ORG,,Sentence boundary between first and second word,False,False,True,True
+train,678,"[562, 572): 'Graafschap'",ORG,Sentence,"[562, 583): 'Graafschap Doetinchem'",,,Sentence boundary between first and second part of name,False,True,False,True
+train,686,"[136, 141): 'India'",LOC,Tag,"[136, 141): 'India'",ORG,,Cricket team,False,False,False,True
+train,686,"[146, 155): 'Sri Lanka'",LOC,Tag,"[146, 155): 'Sri Lanka'",ORG,,Cricket team,False,False,False,True
+train,686,"[170, 175): 'India'",LOC,Tag,"[170, 175): 'India'",ORG,,Cricket team,False,False,False,True
+train,686,"[20, 25): 'INDIA'",LOC,Tag,"[20, 25): 'INDIA'",ORG,,Cricket team,False,False,False,True
+train,686,"[28, 37): 'SRI LANKA'",LOC,Tag,"[28, 37): 'SRI LANKA'",ORG,,Cricket team,False,False,False,True
+train,686,"[665, 674): 'Sri Lanka'",LOC,Tag,"[665, 674): 'Sri Lanka'",ORG,,Cricket team,False,False,False,True
+train,686,"[897, 909): 'Tillekeratne'",PER,Sentence,"[890, 909): 'Hashan Tillekeratne'",PER,,Sentence boundary between first and last name,False,False,True,True
+train,686,"[101, 113): 'World Series'",MISC,Sentence,"[94, 113): 'Singer World Series'",MISC,,"Sentence boundary between ""Singer"" and ""World""",False,False,True,True
+train,686,"[94, 100): 'Singer'",MISC,Sentence,"[94, 113): 'Singer World Series'",,,"Sentence boundary between ""Singer"" and ""World""",False,True,False,True
+train,698,,,Missing,"[1171, 1177): 'Apache'",MISC,,,False,False,True,True
+train,698,"[1994, 2008): 'Crystal Palace'",ORG,Tag,"[1994, 2008): 'Crystal Palace'",LOC,,The world's firstï¿½Boy Scout Rallyï¿½was held atï¿½Crystal Palaceï¿½nearï¿½London.,False,True,False,True
+train,701,"[1072, 1079): 'England'",LOC,Tag,"[1072, 1079): 'England'",ORG,,National rugby team,False,False,False,True
+train,701,"[17, 30): 'union-England'",MISC,Token,"[23, 30): 'England'",ORG,,"English national rugby team: ""Rugbyï¿½union-Englandï¿½given final chance to stay inï¿½Five Nations.""",False,True,True,True
+train,701,"[372, 380): 'Scotland'",LOC,Tag,"[372, 380): 'Scotland'",ORG,,National rugby team,False,False,False,True
+train,701,"[382, 387): 'Wales'",LOC,Tag,"[382, 387): 'Wales'",ORG,,National rugby team,False,False,False,True
+train,701,"[389, 396): 'Ireland'",LOC,Tag,"[389, 396): 'Ireland'",ORG,,National rugby team,False,False,False,True
+train,701,"[401, 407): 'France'",LOC,Tag,"[401, 407): 'France'",ORG,,National rugby team,False,False,False,True
+train,701,"[659, 666): 'England'",LOC,Tag,"[659, 666): 'England'",ORG,,National rugby team,False,False,False,True
+train,701,"[93, 100): 'England'",LOC,Tag,"[93, 100): 'England'",ORG,,"English national rugby team: ""Englandï¿½have been given a final chance to remain in theï¿½Five Nationsï¿½' championshipï¿½""",False,False,False,True
+train,713,,,Missing,"[2362, 2370): 'Belgians'",MISC,,,False,False,True,True
+train,724,,,Missing,"[1233, 1243): 'U.S.-bound'",MISC,,,False,False,True,True
+train,724,"[1299, 1308): 'Salamanca'",LOC,Tag,"[1299, 1308): 'Salamanca'",PER,,,False,False,False,True
+train,724,"[395, 401): 'Adolfo'",PER,Span,"[395, 411): 'Adolfo Salamanca'",PER,,,False,False,False,True
+train,724,"[402, 411): 'Salamanca'",LOC,Wrong,,,,,False,False,False,True
+train,725,"[134, 141): 'Richter'",PER,Tag,"[134, 141): 'Richter'",MISC,,"""Richter scale""",False,False,True,True
+train,734,"[45, 48): 'Kan'",LOC,Span,"[45, 49): 'Kan.'",,,Sentence boundary between period and comma confused human labeler,False,True,False,True
+train,734,"[45, 48): 'Kan'",LOC,Sentence,"[45, 49): 'Kan.'",LOC,,Sentence boundary between period and comma,False,False,True,True
+train,734,"[84, 94): 'JOHNSON CO'",ORG,Sentence,"[84, 95): 'JOHNSON CO.'",ORG,,Sentence boundary between period and comma,False,False,False,True
+train,738,"[585, 601): 'Shabwa Block No.'",MISC,Sentence,"[585, 605): 'Shabwa Block No. S-1'",,,,False,True,False,True
+train,739,"[602, 605): 'S-1'",MISC,Sentence,"[585, 605): 'Shabwa Block No. S-1'",MISC,,"Sentence boundary between ""No."" and ""S-1""",False,False,True,True
+train,758,"[263, 266): 'Ark'",LOC,Sentence,"[263, 267): 'Ark.'",LOC,,Sentence boundary between period and comma,False,False,True,True
+train,758,"[263, 266): 'Ark'",LOC,Span,"[263, 267): 'Ark.'",,,Sentence boundary between period and comma confused human labeler,False,True,False,True
+train,778,"[371, 382): 'Maryborough'",PER,Tag,"[371, 382): 'Maryborough'",LOC,,"The shooting occured around 6.30 a.m. (2030ï¿½GMT) on Tuesday atï¿½Glenwood, south ofï¿½Maryborough,ï¿½",False,True,True,True
+train,778,"[63, 71): 'BRISBANE'",ORG,Tag,"[63, 71): 'BRISBANE'",LOC,,Dateline of article,False,True,True,True
+train,780,"[627, 634): 'Son Sen'",LOC,Tag,"[627, 634): 'Son Sen'",PER,,https://en.wikipedia.org/wiki/Son_Sen,False,False,True,True
+train,780,,,Missing,"[64, 77): 'ARANYAPRATHET'",LOC,,,False,True,True,True
+train,794,"[41, 47): 'Iberia'",ORG,Tag,"[41, 47): 'Iberia'",LOC,,Iberian peninsula,False,False,True,True
+train,800,"[1108, 1115): 'Affleck'",PER,Sentence,"[1103, 1115): 'Paul Affleck'",PER,,Sentence boundary between first and last name,False,False,True,True
+train,800,"[1103, 1107): 'Paul'",PER,Sentence,"[1103, 1115): 'Paul Affleck'",,,Sentence boundary between first and last name,False,True,False,True
+train,800,"[483, 488): 'Davis'",PER,Sentence,"[478, 488): 'Mark Davis'",PER,,Sentence boundary between first and last name,False,False,True,True
+train,800,"[478, 482): 'Mark'",PER,Sentence,"[478, 488): 'Mark Davis'",,,Sentence boundary between first and last name,False,True,False,True
+train,800,"[559, 565): 'Goosen'",PER,Sentence,"[552, 565): 'Retief Goosen'",PER,,Sentence boundary between first and last name,False,False,True,True
+train,800,"[552, 558): 'Retief'",PER,Sentence,"[552, 565): 'Retief Goosen'",,,Sentence boundary between first and last name,False,True,False,True
+train,800,"[835, 842): 'Woosnam'",PER,Sentence,"[831, 842): 'Ian Woosnam'",PER,,Sentence boundary between first and last name,False,False,True,True
+train,800,"[831, 834): 'Ian'",PER,Sentence,"[831, 842): 'Ian Woosnam'",,,Sentence boundary between first and last name,False,True,False,True
+train,800,"[891, 899): 'Eriksson'",PER,Sentence,"[886, 899): 'Klas Eriksson'",PER,,Sentence boundary between first and last name,False,False,True,True
+train,800,"[886, 890): 'Klas'",PER,Sentence,"[886, 899): 'Klas Eriksson'",,,Sentence boundary between first and last name,False,True,False,True
+train,800,"[993, 1000): 'Coltart'",PER,Sentence,"[986, 1000): 'Andrew Coltart'",PER,,Sentence boundary between first and last name,False,False,True,True
+train,800,"[986, 992): 'Andrew'",PER,Sentence,"[986, 1000): 'Andrew Coltart'",,,Sentence boundary between first and last name,False,True,False,True
+train,803,"[794, 806): 'Vasilopoulos'",PER,Sentence,"[786, 806): 'Lampros Vasilopoulos'",PER,,Sentence boundary between first and last name,False,False,True,True
+train,803,"[786, 793): 'Lampros'",PER,Sentence,"[786, 806): 'Lampros Vasilopoulos'",,,Sentence boundary between first and last name,False,True,False,True
+train,808,"[20, 47): 'ENGLISH COUNTY CHAMPIONSHIP'",MISC,Span,"[20, 27): 'ENGLISH'",MISC,,The County Championship is an event held in England,False,False,False,True
+train,808,"[20, 47): 'ENGLISH COUNTY CHAMPIONSHIP'",MISC,Span,"[28, 47): COUNTY CHAMPIONSHIP'",MISC,,The County Championship is an event held in England,False,False,False,True
+train,817,"[1207, 1215): 'NEW YORK'",LOC,Tag,"[1207, 1215): 'NEW YORK'",ORG,,Baseball team,False,False,False,True
+train,817,"[1227, 1234): 'HOUSTON'",LOC,Tag,"[1227, 1234): 'HOUSTON'",ORG,,Baseball team,False,False,False,True
+train,817,"[1249, 1257): 'COLORADO'",LOC,Tag,"[1249, 1257): 'COLORADO'",ORG,,Baseball team,False,False,True,True
+train,817,"[1269, 1279): 'PITTSBURGH'",LOC,Tag,"[1269, 1279): 'PITTSBURGH'",ORG,,Baseball team,False,False,False,True
+train,817,"[1295, 1303): 'MONTREAL'",LOC,Tag,"[1295, 1303): 'MONTREAL'",ORG,,Baseball team,False,False,False,True
+train,817,"[1315, 1323): 'ST LOUIS'",LOC,Tag,"[1315, 1323): 'ST LOUIS'",ORG,,Baseball team,False,False,False,True
+train,817,"[674, 681): 'DETROIT'",LOC,Tag,"[674, 681): 'DETROIT'",ORG,,Baseball team,False,False,False,True
+train,817,"[695, 704): 'MILWAUKEE'",LOC,Tag,"[695, 704): 'MILWAUKEE'",ORG,,Baseball team,False,False,False,True
+train,817,"[717, 727): 'CALIFORNIA'",LOC,Tag,"[717, 727): 'CALIFORNIA'",ORG,,Baseball team,False,False,False,True
+train,817,"[741, 748): 'SEATTLE'",LOC,Tag,"[741, 748): 'SEATTLE'",ORG,,Baseball team,False,False,False,True
+train,817,"[234, 250): 'EASTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+train,817,"[374, 390): 'CENTRAL DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+train,817,"[517, 533): 'WESTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+train,817,"[765, 781): 'EASTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+train,817,"[1045, 1061): 'WESTERN DIVISION'",MISC,Wrong,,,,Divisions of leagues not considered entities,False,False,False,True
+train,819,"[84, 96): 'Major League'",MISC,Sentence,"[84, 105): 'Major League Baseball'",,,"Sentence boundary between ""League"" and ""Baseball""",False,True,False,True
+train,821,"[690, 697): 'Atlanta'",LOC,Tag,"[690, 697): 'Atlanta'",ORG,,Atlanta Braves,False,False,True,True
+train,832,"[419, 427): 'EUROLIRA'",ORG,Tag,"[419, 427): 'EUROLIRA'",MISC,,,False,True,True,True
+train,832,"[452, 461): 'EUROSWISS'",ORG,Tag,"[452, 461): 'EUROSWISS'",MISC,,,False,True,True,True
+train,871,"[193, 204): 'MS-NBC News'",MISC,Tag,"[193, 204): 'MS-NBC News'",ORG,,,False,True,True,True
+train,872,"[221, 239): 'CHICAGO AREA MILLS'",MISC,Both,"[221, 228): 'CHICAGO'",LOC,,,False,True,True,True
+train,872,"[382, 389): 'DECATUR'",ORG,Tag,"[382, 389): 'DECATUR'",LOC,,,False,False,False,True
+train,872,"[395, 419): 'CLINTON AND CEDAR RAPIDS'",ORG,Both,"[395, 402): 'CLINTON'",LOC,,,False,False,False,True
+train,872,"[395, 419): 'CLINTON AND CEDAR RAPIDS'",ORG,Tag,"[395, 419): 'CLINTON AND CEDAR RAPIDS'",LOC,,Two cities in Iowa,False,False,False,True
+train,872,"[395, 419): 'CLINTON AND CEDAR RAPIDS'",ORG,Both,"[407, 419): 'CEDAR RAPIDS'",LOC,,,False,False,False,True
+train,874,"[59, 65): 'RENNES'",ORG,Tag,"[59, 65): 'RENNES'",LOC,,,False,True,True,True
+train,893,"[124, 130): 'Fowler'",PER,Span,"[118, 130): 'Wyche Fowler'",,,,False,False,True,True
+train,893,"[124, 130): 'Fowler'",,Span,"[118, 130): 'Wyche Fowler'",ORG,,,False,True,False,True
+train,918,"[11, 24): 'INTERVIEW-T&N'",,Token,"[11, 24): 'INTERVIEW-T&N'",,,INTERVIEW-T&N' treated as a single token,False,True,False,True
+train,918,"[11, 24): 'INTERVIEW-T&N'",MISC,Token,"[21, 24): 'T&N'",ORG,,"Tokenizer treated ""INVERVIEW-T&N"" as a single token",False,False,True,True
+train,919,"[112, 119): 'Richter'",PER,Tag,"[112, 119): 'Richter'",MISC,,,False,False,True,True
+train,930,"[706, 707): '3'",ORG,Sentence,"[698, 707): 'CDU No. 3'",ORG,,"Sentence boundary between ""No."" and ""3""",False,False,True,True
+train,930,"[698, 705): 'CDU No.'",ORG,Sentence,"[698, 707): 'CDU No. 3'",,,"Sentence boundary between ""No."" and 3",False,True,False,True
+train,937,"[1649, 1652): 'Inc'",ORG,Sentence,"[1626, 1652): 'Goldman, Sachs and Co. Inc'",ORG,,"Sentence boundary between ""Co."" and ""Inc.""",False,False,True,True
+train,937,"[1626, 1648): 'Goldman, Sachs and Co.'",ORG,Sentence,"[1626, 1652): 'Goldman, Sachs and Co. Inc'",,,"Sentence boundary between ""Co."" and ""Inc""",False,True,False,True
+train,944,"[1036, 1042): 'Africa'",LOC,Sentence,"[1030, 1042): 'South Africa'",LOC,,"Sentence boundary between ""South"" and ""Africa""",False,False,True,True
+train,944,"[1030, 1035): 'South'",LOC,Sentence,"[1030, 1042): 'South Africa'",,,"Sentence boundary between ""South"" and ""Africa""",False,True,False,True
+train,944,"[415, 420): 'South'",LOC,Sentence,"[415, 427): 'South Africa'",LOC,,"Sentence boundary between ""South"" and ""Africa""",False,False,True,True
+,163,"[411, 424): 'Conservatives'  ",,Missing,,ORG,,political party,False,False,False,True
+,176,"[2419, 2425): 'Busang'  ",ORG,Tag,"[2419, 2425): 'Busang'  ",LOC,,??? city in Indonesia that has big gold deposits,False,False,False,True
+,176,"[2732, 2738): 'Busang'",ORG,Tag,"[2732, 2738): 'Busang'",LOC,,,False,False,False,True
+,,"[143, 151): 'Tasmania'",LOC,Tag,"[143, 151): 'Tasmania'",ORG,,Cricket team,False,False,False,True
+,,"[156, 164): 'Victoria'",LOC,Tag,"[156, 164): 'Victoria'",ORG,,Cricket team,False,False,False,True
+,,"[267, 286): 'Hapoel Ironi Rishon'",ORG,Span,"[267, 293): 'Hapoel Ironi Rishon Lezion'",,,,False,False,False,True
+,,,,Missing,"[410, 427): 'VERN RIFFE CENTER'",LOC,,https://vrcfa.com/,False,False,False,True
+,,"[419, 427): 'EUROLIRA'",ORG,Tag,"[419, 427): 'EUROLIRA'",MISC,,Reference to futures contracts on Euro/Lira exchange rate,False,False,False,True
+,,"[732, 740): 'Pakistan'",LOC,Tag,"[732, 740): 'Pakistan'",ORG,,Cricket team,False,False,False,True
+,,"[84, 94): 'JOHNSON CO'",ORG,Span,"[84, 95): 'JOHNSON CO.'",,,Sentence boundary between period and comma confused human labeler,False,False,False,True
+,,,,Missing,"[854, 874): 'Overseas Development'",ORG,,Reference to Britain's Overseas Development Administration,False,False,False,True
+,,"[2264, 2267): 'RBI'",MISC,Wrong,,,,Run batted in,False,False,False,True


### PR DESCRIPTION
The file `all_conll_corrections_combined.csv` currently contains a leading column with Pandas index values. The values in this leading column will *all* change if there is a slight difference in the upstream data or if `Label_Stats.ipynb` is run on a different version of Python.

This PR removes the leading column to make future diffs smaller. 